### PR TITLE
Add nixpkgs-update-pypi-release

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -35,6 +35,18 @@
         "url": "https://github.com/ryantm/nixpkgs-update-github-releases/archive/e31b003d8edd400d06b718c717c19532585389f9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "nixpkgs-update-pypi-releases": {
+        "branch": "master",
+        "description": "Fetches releases from pypi for https://github.com/ryantm/nixpkgs-update",
+        "homepage": null,
+        "owner": "jonringer",
+        "repo": "nixpkgs-update-pypi-releases",
+        "rev": "06107e06d086a1c89f53a563876799e3d7f363b2",
+        "sha256": "1r7zf0a5ybbi808qkjdn38142kwi2mfanrn0qkc0ajscp6v5yihn",
+        "type": "tarball",
+        "url": "https://github.com/jonringer/nixpkgs-update-pypi-releases/archive/06107e06d086a1c89f53a563876799e3d7f363b2.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "simple-hydra": {
         "branch": "master",
         "description": "A simple module for enabling Hydra",


### PR DESCRIPTION
Was able to run the script locally, and works as expected with a checkout of nixpkgs.

This does require a local checkout of nixpkgs though.

example result file:
```
$ cat ./package-to-update.txt | head -20
picard 2.2.3 2.3.1 https://pypi.org/project/picard/
friture 0.37 0.38 https://pypi.org/project/friture/
mopidy 2.3.1 3.0.1 https://pypi.org/project/mopidy/
tzupdate 1.5.0 2.0.0 https://pypi.org/project/tzupdate/
menumaker 0.99.11 1.4.1 https://pypi.org/project/menumaker/
buku 4.2.2 4.3 https://pypi.org/project/buku/
cozy 0.6.7 1.0 https://pypi.org/project/cozy/
guake 3.6.3 3.7.0 https://pypi.org/project/guake/
kitty 0.16.0 1.2.0 https://pypi.org/project/kitty/
udiskie 1.7.7 2.1.0 https://pypi.org/project/udiskie/
jrnl 1.9.8 2.3.1 https://pypi.org/project/jrnl/
hovercraft 2.6 2.7 https://pypi.org/project/hovercraft/
deepTools 3.3.1 3.4.1 https://pypi.org/project/deepTools/
snakemake 5.8.1 5.13.0 https://pypi.org/project/snakemake/
gallery_dl 1.12.2 1.13.3 https://pypi.org/project/gallery_dl/
truvari 1.3.2 1.3.4 https://pypi.org/project/truvari/
gnomecast 1.4.1 1.9.5 https://pypi.org/project/gnomecast/
labelImg 1.6.0 1.8.3 https://pypi.org/project/labelImg/
streamlit 0.50.2 0.57.1 https://pypi.org/project/streamlit/
luigi 2.8.11 2.8.12 https://pypi.org/project/luigi/
```