### PR TITLE
Update pypi-releases

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "jonringer",
         "repo": "nixpkgs-update-pypi-releases",
-        "rev": "06107e06d086a1c89f53a563876799e3d7f363b2",
-        "sha256": "1r7zf0a5ybbi808qkjdn38142kwi2mfanrn0qkc0ajscp6v5yihn",
+        "rev": "71a5a092d568f3377092bbe27a4d20c342229d4b",
+        "sha256": "1cnr9195fnipy3rs47m38y2c3zx5z9k0hhsflkadj03srvlzg8zn",
         "type": "tarball",
-        "url": "https://github.com/jonringer/nixpkgs-update-pypi-releases/archive/06107e06d086a1c89f53a563876799e3d7f363b2.tar.gz",
+        "url": "https://github.com/jonringer/nixpkgs-update-pypi-releases/archive/71a5a092d568f3377092bbe27a4d20c342229d4b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "simple-hydra": {


### PR DESCRIPTION
new format for the .txt:
```
python3.7-friture 0.37 0.38 https://pypi.org/project/friture/
python3.7-menumaker 0.99.11 1.4.1 https://pypi.org/project/menumaker/
python3.7-kitty 0.17.2 1.2.0 https://pypi.org/project/kitty/
python3.7-guake 3.6.3 3.7.0 https://pypi.org/project/guake/
python3.7-cozy 0.6.7 1.0 https://pypi.org/project/cozy/
python3.7-hovercraft 2.6 2.7 https://pypi.org/project/hovercraft/
python3.7-jrnl 1.9.8 2.3.1 https://pypi.org/project/jrnl/
python3.7-etesync-dav 0.15.0 0.16.0 https://pypi.org/project/etesync-dav/
python3.7-rofi-mpd 2.0.1 2.1.0 https://pypi.org/project/rofi-mpd/
python3.7-catt 0.10.3 0.11.0 https://pypi.org/project/catt/
python3.7-streamlit 0.50.2 0.57.2 https://pypi.org/project/streamlit/
python3.7-labelImg 1.8.1 1.8.3 https://pypi.org/project/labelImg/
python3.7-nvpy 0.9.7 2.1.0 https://pypi.org/project/nvpy/
python3.7-gnomecast 1.4.1 1.9.5 https://pypi.org/project/gnomecast/
python3.7-jellyfin-mpv-shim 1.4.2 1.5.4 https://pypi.org/project/jellyfin-mpv-shim/
```

this is to avoid the situation where the `buildPythonApplication` and `buildPythonPackage` both prefix the derivation name:
```
[15:12:16] jon@jon-desktop /home/jon/projects/nixpkgs (master)
$ nix-env -f . -qa Flask-WTF-0.14.2 --attr-path
error: selector 'Flask-WTF-0.14.2' matches no derivations
[15:25:23] jon@jon-desktop /home/jon/projects/nixpkgs (master)
$ nix-env -f . -qa python3.7-Flask-WTF-0.14.2 --attr-path
python37Packages.flask_wtf  python3.7-Flask-WTF-0.14.2
```

this should work for almost all `python-module` updates. And python3 application updates.