### PR TITLE
Update pypi-releases, filter drv-names

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "jonringer",
         "repo": "nixpkgs-update-pypi-releases",
-        "rev": "71a5a092d568f3377092bbe27a4d20c342229d4b",
-        "sha256": "1cnr9195fnipy3rs47m38y2c3zx5z9k0hhsflkadj03srvlzg8zn",
+        "rev": "8c65d950f17eca1fb46f0f3074b979302290d9f5",
+        "sha256": "04bmxxdabmwfibnsjdijq6y79dsmw514vqjvl57lj1x8fzgjmfz4",
         "type": "tarball",
-        "url": "https://github.com/jonringer/nixpkgs-update-pypi-releases/archive/71a5a092d568f3377092bbe27a4d20c342229d4b.tar.gz",
+        "url": "https://github.com/jonringer/nixpkgs-update-pypi-releases/archive/8c65d950f17eca1fb46f0f3074b979302290d9f5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "simple-hydra": {


### PR DESCRIPTION
my previous changes increase the noise to signal significantly with:
```
Raw command: nix-env -qa python3.7-pubs-0.8.2 -f . --attr-path --arg config "{ allowBroken = true; allowUnfree = true; allowAliases = false; }" --arg overlays "[ ]"
Standard output:

error: selector 'python3.7-pubs-0.8.2' matches no derivations
```

This change includes the https://github.com/jonringer/nixpkgs-update-pypi-releases/commit/6f6833d605d24c4857583b1438f221049c2c3a0a changes I did which will look up the prefix for the drv-name based upon `pname` and `current_version`. Python2 derivations, and aliases are filtered out.

Time spent in `nix-env -qa` is amortized that it the file containing all the drv-names is generated once, and read many times.

```
INFO:root:Checked 3609 packages, 3010 updated
INFO:root:########## END OF NIXPKGS_UPDATE_PYPI_RELEASES ##########

real	0m54.292s
user	1m27.671s
sys	0m51.388s
```

example output can be found: https://gist.github.com/jonringer/66617f4e2add4ffaaeb09ba5b180e377