### PR TITLE
nixpkgs-update-pypi-releases: use NIX_PATH and re-enable

### DIFF
--- a/build01/nixpkgs-update.nix
+++ b/build01/nixpkgs-update.nix
@@ -63,10 +63,10 @@ in
     serviceConfig = nixpkgsUpdateServiceConfigCommon;
 
     script = ''
-      # nixpkgs-update delete-done
-      # grep -rl $XDG_CACHE_HOME/nixpkgs -e buildPython | grep default | \
-      #   ${nixpkgs-update-pypi-releases} > /var/lib/nixpkgs-update/packages-to-update.txt
-      # nixpkgs-update update-list --pr --cve --cachix --outpaths --nixpkgs-review
+      nixpkgs-update delete-done
+      grep -rl $XDG_CACHE_HOME/nixpkgs -e buildPython | grep default | \
+        ${nixpkgs-update-pypi-releases} > /var/lib/nixpkgs-update/packages-to-update.txt
+      nixpkgs-update update-list --pr --cve --cachix --outpaths --nixpkgs-review
       nixpkgs-update delete-done
       ${nixpkgs-update-github-releases} > /var/lib/nixpkgs-update/packages-to-update.txt
       nixpkgs-update update-list --pr --cve --cachix --outpaths --nixpkgs-review

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "jonringer",
         "repo": "nixpkgs-update-pypi-releases",
-        "rev": "8c65d950f17eca1fb46f0f3074b979302290d9f5",
-        "sha256": "04bmxxdabmwfibnsjdijq6y79dsmw514vqjvl57lj1x8fzgjmfz4",
+        "rev": "cf72f9a94b0ccc306c025eba222a70456378433d",
+        "sha256": "05slhzn56gn2pipqi7a9d49q3avh2w7x9q4pibh1adc1wfs60r1w",
         "type": "tarball",
-        "url": "https://github.com/jonringer/nixpkgs-update-pypi-releases/archive/8c65d950f17eca1fb46f0f3074b979302290d9f5.tar.gz",
+        "url": "https://github.com/jonringer/nixpkgs-update-pypi-releases/archive/cf72f9a94b0ccc306c025eba222a70456378433d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "simple-hydra": {


### PR DESCRIPTION
includes https://github.com/jonringer/nixpkgs-update-pypi-releases/commit/cf72f9a94b0ccc306c025eba222a70456378433d which doesn't use the `-f .` args to nix-env, and instead generates the list off NIX_PATH