### PR TITLE
Use XDG_CACHE_HOME to point to nixpkgs

### DIFF
--- a/build01/nixpkgs-update.nix
+++ b/build01/nixpkgs-update.nix
@@ -63,7 +63,7 @@ in
     # API_TOKEN is used by nixpkgs-update-github-releases
     environment.API_TOKEN_FILE = "/var/lib/nixpkgs-update/github_token_with_username.txt";
     # Used by nixpkgs-update-github-releases to install python dependencies
-    environment.NIX_PATH = "nixpkgs=${sources.nixpkgs}";
+    environment.NIX_PATH = "nixpkgs=$XDG_CACHE_HOME/nixpkgs";
 
     serviceConfig = nixpkgsUpdateServiceConfigCommon;
 


### PR DESCRIPTION
supercede: https://github.com/nix-community/infra/pull/18

just need the `nix-env -qa ` command to get the latest nixpkgs, I don't need to update the nixpkgs checkout for the entire build :)