### PR TITLE
secrets: only remove suffix "\n" for the buildkite token

### DIFF
--- a/deployment.nix
+++ b/deployment.nix
@@ -1,5 +1,21 @@
+with builtins;
+
 let
   secrets = import ./secrets.nix;
+
+  # Copied from <nixpkgs/lib>
+  removeSuffix = suffix: str:
+    let
+      sufLen = stringLength suffix;
+      sLen = stringLength str;
+    in
+    if
+      sufLen <= sLen && suffix == substring (sLen - sufLen) sufLen str
+    then
+      substring 0 (sLen - sufLen) str
+    else
+      str;
+
 in
 {
 
@@ -15,7 +31,7 @@ in
         deployment.targetHost = "94.130.143.84";
 
         deployment.keys.buildkite-token = {
-          text = secrets.buildkite-token;
+          text = removeSuffix "\n" secrets.buildkite-token;
           user = "buildkite-agent-ci";
           permissions = "0600";
         };

--- a/secrets.nix
+++ b/secrets.nix
@@ -1,22 +1,6 @@
 with builtins;
 let
-  # Copied from <nixpkgs/lib>
-  removeSuffix = suffix: str:
-    let
-      sufLen = stringLength suffix;
-      sLen = stringLength str;
-    in
-    if
-      sufLen <= sLen && suffix == substring (sLen - sufLen) sufLen str
-    then
-      substring 0 (sLen - sufLen) str
-    else
-      str;
-
-  # Copied from <nixpkgs/lib>
-  fileContents = file: removeSuffix "\n" (builtins.readFile file);
-
-  readSecret = name: fileContents (./secrets + "/${name}");
+  readSecret = name: readFile (./secrets + "/${name}");
 in
 mapAttrs
   (name: type: if type != "directory" then readSecret name else null)


### PR DESCRIPTION
The SSH private key file needs to have a last empty new
line. Otherwise, SSH fails with:

    Load key "/path/to/key": invalid format
