### PR TITLE
add CNAME for *.nix-community.org to github pages

### DIFF
--- a/terraform/cloudflare_nix-community_org.tf
+++ b/terraform/cloudflare_nix-community_org.tf
@@ -52,3 +52,19 @@ resource "cloudflare_record" "mumble-AAAA" {
   value   = "2a03:3b40:fe:ab::1"
   type    = "AAAA"
 }
+
+# For each github page, create a CNAME alias to nix-community.github.io
+locals {
+  github_pages = [
+    "nur"
+  ]
+}
+
+resource "cloudflare_record" "nix-community-org-github-pages" {
+  for_each = {for page in local.github_pages: page => page}
+
+  zone_id = local.nix_community_org_zone_id
+  name    = each.value
+  value   = "nix-community.github.io"
+  type    = "CNAME"
+}


### PR DESCRIPTION
What do you think of this?

It would allow to, for example, have https://nur.nix-community.org/ instead of https://nix-community.github.io/nur-search/

/cc @Mic92 
