### PR TITLE
hydra: add Redoxpkgs project

### DIFF
--- a/build01/hydra-declarative-projects.nix
+++ b/build01/hydra-declarative-projects.nix
@@ -16,5 +16,12 @@
       description = "A complete and Simple Nixos Mailserver";
       homepage = "https://gitlab.com/simple-nixos-mailserver/nixos-mailserver";
     };
+    redoxpkgs = {
+      displayName = "Redoxpkgs";
+      inputValue = "https://github.com/nix-community/redoxpkgs";
+      specFile = ".hydra/spec.json";
+      description = "Packages for Redox";
+      homepage = "https://github.com/nix-community/redoxpkgs";
+    };
   };
 }


### PR DESCRIPTION
The Hydra declarative project configuration is not part of the Redoxpkgs repository yet (see https://github.com/nix-community/redoxpkgs/pull/2).