### PR TITLE
remove nixos wiki

### DIFF
--- a/services/hound/hound.json
+++ b/services/hound/hound.json
@@ -217,12 +217,6 @@
             "vcs-config": {
                 "ref": "master"
             }
-        },
-        "nixos-users-wiki-wiki": {
-            "url": "https://github.com/nixos-users/wiki.wiki.git",
-            "url-pattern": {
-                "base-url": "{url}/{path}"
-            }
         }
     }
 }


### PR DESCRIPTION
This is no longer maintained. People should go to nixos.wiki instead.