### PR TITLE
roles/security: allow sudo without password

### DIFF
--- a/roles/security.nix
+++ b/roles/security.nix
@@ -1,6 +1,8 @@
 { config, pkgs, lib, ... }:
 
 {
+  # Make sure that the firewall is enabled, even if it's the default.
+  networking.firewall.enable = true;
 
   # Allow sudo from SSH authenticated users
   # This requires users in the wheel group to log in
@@ -8,17 +10,18 @@
   security.pam.services.sudo.sshAgentAuth = true;
   security.pam.enableSSHAgentAuth = true;
 
+  # Allow password-less sudo for wheel users
+  security.sudo.enable = true;
+  security.sudo.wheelNeedsPassword = false;
+
   # Dont let users create their own authorized keys files
   services.openssh.authorizedKeysFiles = lib.mkForce [
     "/etc/ssh/authorized_keys.d/%u"
   ];
-
-  networking.firewall.enable = true;
 
   services.openssh.challengeResponseAuthentication = false;
   services.openssh.passwordAuthentication = false;
 
   # Ban brute force SSH
   services.fail2ban.enable = true;
-
 }


### PR DESCRIPTION
Encourage users to SSH as their own users. User accounts were not able
to `sudo` as they don't have a password associated to them.