### PR TITLE
add rust-for-linux hydra job

### DIFF
--- a/services/hydra/declarative-projects.nix
+++ b/services/hydra/declarative-projects.nix
@@ -30,5 +30,12 @@
       description = "Packages for Redox";
       homepage = "https://github.com/nix-community/redoxpkgs";
     };
+    rust-for-linux = {
+      displayName = "Rust For Linux";
+      inputValue = "https://github.com/rust-for-linux/nix";
+      specFile = ".hydra/spec.json";
+      description = "Linux Kernel with Rust support";
+      homepage = "https://github.com/Rust-for-Linux/linux";
+    };
   };
 }


### PR DESCRIPTION
This adds hydra ci jobs for the rust-for-linux linux tree.

I spoke with @Mic92 about adding this to the nix-community hydra.