### PR TITLE
build01: shutdown gitlab runner

### DIFF
--- a/build01/configuration.nix
+++ b/build01/configuration.nix
@@ -16,7 +16,6 @@
     ../roles/buildkite.nix
     ../roles/common.nix
     ../roles/docker.nix
-    ../roles/gitlab-runner.nix
     ../roles/hetzner-network.nix
     ../roles/nginx.nix
     ../roles/nix-community-cache.nix

--- a/deployment.nix
+++ b/deployment.nix
@@ -47,12 +47,6 @@ in
         permissions = "0600";
       };
 
-      deployment.keys.gitlab-runner-registration = {
-        text = secrets.gitlab-runner-registration;
-        user = "gitlab-runner";
-        permissions = "0600";
-      };
-
       deployment.keys."marvin-mk2-key.pem" = {
         text = secrets."marvin-mk2-key.pem";
         destDir = "/var/lib/marvin-mk2";

--- a/roles/gitlab-runner.nix
+++ b/roles/gitlab-runner.nix
@@ -1,4 +1,10 @@
 { pkgs, ... }:
+## requires this secret in deployment.nix
+#deployment.keys.gitlab-runner-registration = {
+#  text = secrets.gitlab-runner-registration;
+#  user = "gitlab-runner";
+#  permissions = "0600";
+#};
 let
   gitlabModule = builtins.fetchTarball {
     url = "https://gitlab.com/arianvp/nixos-gitlab-runner/-/archive/9126927c701aa399bd1734e7e5230c3a0010c1b7/nixos-gitlab-runner-9126927c701aa399bd1734e7e5230c3a0010c1b7.tar.gz";


### PR DESCRIPTION
emacs-overlay uses now github actions successfully for a while: https://github.com/nix-community/emacs-overlay/actions