### PR TITLE
pin nixopsUnstable to working version

### DIFF
--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -2,8 +2,11 @@ let
   nix-community-infra = pkgs: rec {
     inherit (pkgs)
       git-crypt
-      niv;
-    nixopsUnstable = (pkgs.nixopsUnstable.withPlugins (ps: [ ]));
+      niv
+      sources;
+    nixopsUnstable =
+      let nixopsPkgs = import sources.nixops-nixpkgs {};
+      in (nixopsPkgs.nixopsUnstable.withPlugins (ps: [ ]));
 
     terraform = pkgs.terraform_1_0.withPlugins (
       p: [

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -23,6 +23,18 @@
         "url": "https://github.com/timokau/marvin-mk2/archive/b3dd8c02a5c01dcf0e9cc8789846a0ec980f534b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "nixops-nixpkgs": {
+        "branch": "master",
+        "description": "Nix Packages collection",
+        "homepage": "",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f2f8e282",
+        "sha256": "1gflpsgagg487xj5p9911b7pvqh2vmw7vfg4hi6pnbrqkilm5kj6",
+        "type": "tarball",
+        "url": "https://github.com/nixos/nixpkgs/archive/f2f8e282.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "nixpkgs": {
         "branch": "nixos-unstable-small",
         "description": "Nix Packages collection",


### PR DESCRIPTION
nixopsUnstable changed a lot and appears to be broken in various ways. Like it doesn't respect the --state flag anymore and choosing the memory or legacy state backends doesn't seem to work. Switching to nixops isn't an option either since it is broken on master.

This adds a new niv pin for nixops that pins it to the last master rev we were on that worked.