### PR TITLE
hydra: upload cachix directly

### DIFF
--- a/build03/configuration.nix
+++ b/build03/configuration.nix
@@ -16,7 +16,6 @@
     ../roles/common.nix
     ../roles/hetzner-network.nix
     ../roles/nginx.nix
-    ../roles/nix-community-cache.nix
 
     ../services/hound
     ../services/hydra


### PR DESCRIPTION
This no longer requires stopping hydra when doing nix-gc to avoid
race conditions in cachix-watch store.