### PR TITLE
Enable aarch64 emulation on Hydra systems

### DIFF
--- a/services/hydra/default.nix
+++ b/services/hydra/default.nix
@@ -140,12 +140,14 @@ in
       buildMachines = [
         {
           hostName = "localhost";
-          systems = [ "x86_64-linux" "builtin" ];
+          systems = [ "x86_64-linux" "aarch64-linux" "builtin" ];
           maxJobs = 8;
           supportedFeatures = [ "nixos-test" "big-parallel" "kvm" ];
         }
       ];
     };
+
+    boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 
     services.nginx.virtualHosts = {
       "hydra.nix-community.org" = {


### PR DESCRIPTION
I would like to build Emacs for aarch64 and have it in the binary cache.

Note that this is only intended for the Emacs distribution itself and not it's thousands of packages.