### PR TITLE
hydra-jobsets.tf: update canonical Kittybox source

### DIFF
--- a/terraform/hydra-jobsets.tf
+++ b/terraform/hydra-jobsets.tf
@@ -2,7 +2,7 @@ resource "hydra_project" "kittybox" {
   name         = "kittybox"
   display_name = "Kittybox"
   description  = "The IndieWeb blogging solution"
-  homepage     = "https://gitlab.com/kittybox/kittybox"
+  homepage     = "https://sr.ht/~vikanezrimaya/kittybox"
   owner        = "admin"
   enabled      = true
   visible      = true
@@ -17,7 +17,7 @@ resource "hydra_jobset" "kittybox" {
   type        = "flake"
   description = "main branch"
 
-  flake_uri = "gitlab:kittybox/kittybox"
+  flake_uri = "git+https://git.sr.ht/~vikanezrimaya/kittybox?ref=main"
 
   check_interval    = 300
   scheduling_shares = 3000


### PR DESCRIPTION
Kittybox moved to Sourcehut. Update the flake URI and homepage URI to reflect that.