### PR TITLE
builder/users: make raitobezarius trusted

### DIFF
--- a/roles/builder/users.nix
+++ b/roles/builder/users.nix
@@ -27,7 +27,10 @@ let
       keys = ./keys/jtojnar;
     };
 
-    raitobezarius.keys = ./keys/raitobezarius;
+    raitobezarius = {
+      trusted = true;
+      keys = ./keys/raitobezarius;
+    };
 
     winter.keys = ./keys/winter;
 


### PR DESCRIPTION
As many derivations require in-fact to be trusted (input-addressed ones, NixOS tests, non-signed stuff), I am more often forced to disable the builder, so it is earlier than I expected, but I would like to request the trusted status.

Of course, if this is not the good time, we can let this PR open and merge when the community feels it is the good time to do it.

In the meantime, thank you for everything you do :)