### PR TITLE
bors: fix merge commit message

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,4 @@
+cut_body_after = "" # don't include text from the PR body in the merge commit message
 status = [
   "ci/hercules/derivations",
   "ci/hercules/effects",


### PR DESCRIPTION
<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->

bors defaults to including the text from the PR body in the merge commit message but also picks up the hidden text in PR template, see https://github.com/nix-community/infra/commit/871821115399a9948da43ec1adfe0caf6c114934

Easier to drop the entire PR body and just use the PR title.