### PR TITLE
ci: remove effects deployment

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -5,36 +5,9 @@
 let
   self = builtins.getFlake (toString ./.);
   nixpkgs = self.inputs.nixpkgs;
-  pkgs = nixpkgs.legacyPackages.x86_64-linux;
-  effects = self.inputs.hercules-ci-effects.lib.withPkgs nixpkgs.legacyPackages.x86_64-linux;
-
-  deployNixOS = args@{
-    hostname,
-    drv,
-    knownHosts,
-      ...
-  }: effects.runIf (src.ref == "refs/heads/master") (effects.mkEffect (args // {
-    secretsMap.ssh = "default-ssh";
-    # This style of variable passing allows overrideAttrs and modification in
-    # hooks like the userSetupScript.
-    inherit hostname drv knownHosts;
-    effectScript = ''
-      export PATH=$PATH:${pkgs.openssh}/bin
-      writeSSHKey ssh ~/.ssh/id_ed25519
-      echo "$knownHosts" >>~/.ssh/known_hosts
-      ssh root@"$hostname" "\$(nix-store -r $drv)/bin/switch-to-configuration switch"
-    '';
-  }));
   stripDomain = name: nixpkgs.lib.head (builtins.match "(.*).nix-community.org" name);
-  deployNixOS' = name: config: nixpkgs.lib.nameValuePair "deploy-${stripDomain name}" (deployNixOS {
-    hostname = config.config.networking.fqdn;
-    knownHosts = config.config.environment.etc."ssh/ssh_known_hosts".text;
-    drv = builtins.unsafeDiscardStringContext config.config.system.build.toplevel.drvPath;
-  });
 in
 (nixpkgs.lib.mapAttrs' (name: config: nixpkgs.lib.nameValuePair "nixos-${stripDomain name}" config.config.system.build.toplevel) self.outputs.nixosConfigurations) //
-# FIXME: broken just now in hercules
-#(nixpkgs.lib.mapAttrs' deployNixOS' self.outputs.nixosConfigurations) //
 {
   # FIXME: maybe find a more generic solution here?
   devShell-x86_64 = self.outputs.devShells.x86_64-linux.default;

--- a/flake.lock
+++ b/flake.lock
@@ -117,24 +117,6 @@
         "type": "github"
       }
     },
-    "hercules-ci-effects": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1664386111,
-        "narHash": "sha256-VCQzAMEjgXNTbAB8v5eQav/KpOC44E/RapXz1KPhroE=",
-        "owner": "hercules-ci",
-        "repo": "hercules-ci-effects",
-        "rev": "ac59fc51b1f25b6436ed55d7cdb5fdd051cd4dbf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "hercules-ci-effects",
-        "type": "github"
-      }
-    },
     "hydra": {
       "inputs": {
         "nix": "nix",
@@ -197,7 +179,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -320,7 +302,7 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "mmdoc": "mmdoc",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1663535874,
@@ -370,21 +352,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1664384182,
-        "narHash": "sha256-RM7C+6c9oSeZuoCCXOCRZUI1o4wpLo6pmOz1PxMN1ig=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "52392d42c156db5b889db7f3cc3e9909e4259b2a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1657693803,
         "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
         "owner": "NixOS",
@@ -399,7 +366,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1664729105,
         "narHash": "sha256-jriM5XldII1rs3v4EWPqHYZdmyRxqE6pRUlINxNwVE8=",
@@ -415,7 +382,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1629859457,
         "narHash": "sha256-JlAU1EboVCOJeMXNLJusf+0vnx++xK1Y4DW5y80zMfY=",
@@ -458,9 +425,8 @@
         "deploykit": "deploykit",
         "flake-parts": "flake-parts",
         "hercules-ci-agent": "hercules-ci-agent",
-        "hercules-ci-effects": "hercules-ci-effects",
         "hydra": "hydra",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-stable": "nixpkgs-stable",
         "nixpkgs-update": "nixpkgs-update",
         "nixpkgs-update-github-releases": "nixpkgs-update-github-releases",

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,6 @@
     nixpkgs-update-pypi-releases.flake = false;
     sops-nix.url = "github:Mic92/sops-nix";
     sops-nix.inputs.nixpkgs.follows = "nixpkgs";
-    hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
     hercules-ci-agent.url = "github:hercules-ci/hercules-ci-agent/master";
     hydra.url = "github:NixOS/hydra";
     # switch back to unstable when NixOS/nix moves to 22.11

--- a/roles/users.nix
+++ b/roles/users.nix
@@ -21,7 +21,7 @@ in
 
   # Assign keys from all users in wheel group
   # This is only done because nixops cant be deployed from any other account
-  users.extraUsers.root.openssh.authorizedKeys.keys = (lib.unique (
+  users.extraUsers.root.openssh.authorizedKeys.keys = lib.unique (
     lib.flatten (
       builtins.map (u: u.openssh.authorizedKeys.keys)
         (
@@ -31,8 +31,5 @@ in
           )
         )
     )
-  )) ++ [
-    # used by hercules
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIjsihPp4fAXUknBtDCBt5tpP7nIjWLdmNiDT34NJYzq deploy-key"
-  ];
+  );
 }


### PR DESCRIPTION
<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->

Probably not much need for effects deployment with hourly auto upgrades. (Though maybe we should set up something to monitor the auto upgrades?)

Looks like the ssh key is in sops but someone else will need to remove that.