### PR TITLE
hound: only include repos that aren't archived or forked

### DIFF
--- a/services/hound/hound.json
+++ b/services/hound/hound.json
@@ -5,14 +5,29 @@
         "NixOS-.github": {
             "url": "https://github.com/NixOS/.github.git"
         },
+        "NixOS-bundlers": {
+            "url": "https://github.com/NixOS/bundlers.git"
+        },
         "NixOS-cabal2nix": {
             "url": "https://github.com/NixOS/cabal2nix.git"
+        },
+        "NixOS-calamares-nixos-extensions": {
+            "url": "https://github.com/NixOS/calamares-nixos-extensions.git"
         },
         "NixOS-darwin-stubs": {
             "url": "https://github.com/NixOS/darwin-stubs.git"
         },
+        "NixOS-distribution-nixpkgs": {
+            "url": "https://github.com/NixOS/distribution-nixpkgs.git"
+        },
+        "NixOS-equinix-metal-builders": {
+            "url": "https://github.com/NixOS/equinix-metal-builders.git"
+        },
         "NixOS-flake-registry": {
             "url": "https://github.com/NixOS/flake-registry.git"
+        },
+        "NixOS-hackage-db": {
+            "url": "https://github.com/NixOS/hackage-db.git"
         },
         "NixOS-hydra": {
             "url": "https://github.com/NixOS/hydra.git"
@@ -23,17 +38,29 @@
         "NixOS-hydra-provisioner": {
             "url": "https://github.com/NixOS/hydra-provisioner.git"
         },
+        "NixOS-jailbreak-cabal": {
+            "url": "https://github.com/NixOS/jailbreak-cabal.git"
+        },
+        "NixOS-language-nix": {
+            "url": "https://github.com/NixOS/language-nix.git"
+        },
         "NixOS-mobile-nixos": {
             "url": "https://github.com/NixOS/mobile-nixos.git"
         },
         "NixOS-mobile-nixos-website": {
             "url": "https://github.com/NixOS/mobile-nixos-website.git"
         },
+        "NixOS-moderation": {
+            "url": "https://github.com/NixOS/moderation.git"
+        },
         "NixOS-mvn2nix-maven-plugin": {
             "url": "https://github.com/NixOS/mvn2nix-maven-plugin.git"
         },
         "NixOS-nix": {
             "url": "https://github.com/NixOS/nix.git"
+        },
+        "NixOS-nix-book": {
+            "url": "https://github.com/NixOS/nix-book.git"
         },
         "NixOS-nix-eclipse": {
             "url": "https://github.com/NixOS/nix-eclipse.git"
@@ -47,11 +74,17 @@
         "NixOS-nix-pills": {
             "url": "https://github.com/NixOS/nix-pills.git"
         },
+        "NixOS-nix.dev": {
+            "url": "https://github.com/NixOS/nix.dev.git"
+        },
         "NixOS-nixops": {
             "url": "https://github.com/NixOS/nixops.git"
         },
         "NixOS-nixops-aws": {
             "url": "https://github.com/NixOS/nixops-aws.git"
+        },
+        "NixOS-nixops-dashboard": {
+            "url": "https://github.com/NixOS/nixops-dashboard.git"
         },
         "NixOS-nixops-hetzner": {
             "url": "https://github.com/NixOS/nixops-hetzner.git"
@@ -65,11 +98,17 @@
         "NixOS-nixos-common-styles": {
             "url": "https://github.com/NixOS/nixos-common-styles.git"
         },
+        "NixOS-nixos-foundation": {
+            "url": "https://github.com/NixOS/nixos-foundation.git"
+        },
         "NixOS-nixos-hardware": {
             "url": "https://github.com/NixOS/nixos-hardware.git"
         },
         "NixOS-nixos-homepage": {
             "url": "https://github.com/NixOS/nixos-homepage.git"
+        },
+        "NixOS-nixos-metrics": {
+            "url": "https://github.com/NixOS/nixos-metrics.git"
         },
         "NixOS-nixos-org-configurations": {
             "url": "https://github.com/NixOS/nixos-org-configurations.git"
@@ -82,6 +121,9 @@
         },
         "NixOS-nixos-status": {
             "url": "https://github.com/NixOS/nixos-status.git"
+        },
+        "NixOS-nixos-summer": {
+            "url": "https://github.com/NixOS/nixos-summer.git"
         },
         "NixOS-nixos-weekly": {
             "url": "https://github.com/NixOS/nixos-weekly.git"
@@ -97,6 +139,9 @@
         },
         "NixOS-ofborg": {
             "url": "https://github.com/NixOS/ofborg.git"
+        },
+        "NixOS-package-list": {
+            "url": "https://github.com/NixOS/package-list.git"
         },
         "NixOS-patchelf": {
             "url": "https://github.com/NixOS/patchelf.git"
@@ -131,11 +176,20 @@
         "nix-community-NUR": {
             "url": "https://github.com/nix-community/NUR.git"
         },
+        "nix-community-NixNG": {
+            "url": "https://github.com/nix-community/NixNG.git"
+        },
+        "nix-community-NixOS-WSL": {
+            "url": "https://github.com/nix-community/NixOS-WSL.git"
+        },
         "nix-community-aarch64-build-box": {
             "url": "https://github.com/nix-community/aarch64-build-box.git"
         },
         "nix-community-acpi_call": {
             "url": "https://github.com/nix-community/acpi_call.git"
+        },
+        "nix-community-all-cabal-json": {
+            "url": "https://github.com/nix-community/all-cabal-json.git"
         },
         "nix-community-awesome-nix": {
             "url": "https://github.com/nix-community/awesome-nix.git"
@@ -146,20 +200,35 @@
         "nix-community-bundix": {
             "url": "https://github.com/nix-community/bundix.git"
         },
-        "nix-community-carnix": {
-            "url": "https://github.com/nix-community/carnix.git"
+        "nix-community-comma": {
+            "url": "https://github.com/nix-community/comma.git"
+        },
+        "nix-community-crystal2nix": {
+            "url": "https://github.com/nix-community/crystal2nix.git"
         },
         "nix-community-disko": {
             "url": "https://github.com/nix-community/disko.git"
         },
-        "nix-community-docker-nix": {
-            "url": "https://github.com/nix-community/docker-nix.git"
-        },
         "nix-community-docker-nixpkgs": {
             "url": "https://github.com/nix-community/docker-nixpkgs.git"
         },
+        "nix-community-dream2nix": {
+            "url": "https://github.com/nix-community/dream2nix.git"
+        },
+        "nix-community-dream2nix-nodejs-auto": {
+            "url": "https://github.com/nix-community/dream2nix-nodejs-auto.git"
+        },
+        "nix-community-dreampkgs": {
+            "url": "https://github.com/nix-community/dreampkgs.git"
+        },
+        "nix-community-eask2nix": {
+            "url": "https://github.com/nix-community/eask2nix.git"
+        },
         "nix-community-emacs-overlay": {
             "url": "https://github.com/nix-community/emacs-overlay.git"
+        },
+        "nix-community-emacs2nix": {
+            "url": "https://github.com/nix-community/emacs2nix.git"
         },
         "nix-community-fenix": {
             "url": "https://github.com/nix-community/fenix.git"
@@ -170,17 +239,17 @@
         "nix-community-flake-nimble": {
             "url": "https://github.com/nix-community/flake-nimble.git"
         },
-        "nix-community-flake.nix": {
-            "url": "https://github.com/nix-community/flake.nix.git"
-        },
         "nix-community-gnome-session-ctl": {
             "url": "https://github.com/nix-community/gnome-session-ctl.git"
         },
+        "nix-community-go-nix": {
+            "url": "https://github.com/nix-community/go-nix.git"
+        },
+        "nix-community-gomod2nix": {
+            "url": "https://github.com/nix-community/gomod2nix.git"
+        },
         "nix-community-google-summer-of-code": {
             "url": "https://github.com/nix-community/google-summer-of-code.git"
-        },
-        "nix-community-govendor": {
-            "url": "https://github.com/nix-community/govendor.git"
         },
         "nix-community-hardware-mnt-reform": {
             "url": "https://github.com/nix-community/hardware-mnt-reform.git"
@@ -200,8 +269,11 @@
         "nix-community-infra": {
             "url": "https://github.com/nix-community/infra.git"
         },
-        "nix-community-ld-getby": {
-            "url": "https://github.com/nix-community/ld-getby.git"
+        "nix-community-label-approved": {
+            "url": "https://github.com/nix-community/label-approved.git"
+        },
+        "nix-community-lib-aggregate": {
+            "url": "https://github.com/nix-community/lib-aggregate.git"
         },
         "nix-community-linuxkit-nix": {
             "url": "https://github.com/nix-community/linuxkit-nix.git"
@@ -215,29 +287,50 @@
         "nix-community-mavenix": {
             "url": "https://github.com/nix-community/mavenix.git"
         },
+        "nix-community-mediawiki-matrix-bot": {
+            "url": "https://github.com/nix-community/mediawiki-matrix-bot.git"
+        },
         "nix-community-meetup-london": {
             "url": "https://github.com/nix-community/meetup-london.git"
+        },
+        "nix-community-naersk": {
+            "url": "https://github.com/nix-community/naersk.git"
+        },
+        "nix-community-napalm": {
+            "url": "https://github.com/nix-community/napalm.git"
         },
         "nix-community-neovim-nightly-overlay": {
             "url": "https://github.com/nix-community/neovim-nightly-overlay.git"
         },
-        "nix-community-nix": {
-            "url": "https://github.com/nix-community/nix.git"
-        },
         "nix-community-nix-community.org": {
             "url": "https://github.com/nix-community/nix-community.org.git"
         },
-        "nix-community-nix-data": {
-            "url": "https://github.com/nix-community/nix-data.git"
+        "nix-community-nix-data-science": {
+            "url": "https://github.com/nix-community/nix-data-science.git"
         },
         "nix-community-nix-direnv": {
             "url": "https://github.com/nix-community/nix-direnv.git"
         },
+        "nix-community-nix-doom-emacs": {
+            "url": "https://github.com/nix-community/nix-doom-emacs.git"
+        },
         "nix-community-nix-environments": {
             "url": "https://github.com/nix-community/nix-environments.git"
         },
+        "nix-community-nix-eval-jobs": {
+            "url": "https://github.com/nix-community/nix-eval-jobs.git"
+        },
+        "nix-community-nix-installers": {
+            "url": "https://github.com/nix-community/nix-installers.git"
+        },
         "nix-community-nix-review-tools": {
             "url": "https://github.com/nix-community/nix-review-tools.git"
+        },
+        "nix-community-nix-snippets": {
+            "url": "https://github.com/nix-community/nix-snippets.git"
+        },
+        "nix-community-nix-straight.el": {
+            "url": "https://github.com/nix-community/nix-straight.el.git"
         },
         "nix-community-nix-travis-ci": {
             "url": "https://github.com/nix-community/nix-travis-ci.git"
@@ -245,8 +338,17 @@
         "nix-community-nix-user-chroot": {
             "url": "https://github.com/nix-community/nix-user-chroot.git"
         },
+        "nix-community-nixago": {
+            "url": "https://github.com/nix-community/nixago.git"
+        },
+        "nix-community-nixago-extensions": {
+            "url": "https://github.com/nix-community/nixago-extensions.git"
+        },
         "nix-community-nixbox": {
             "url": "https://github.com/nix-community/nixbox.git"
+        },
+        "nix-community-nixdoc": {
+            "url": "https://github.com/nix-community/nixdoc.git"
         },
         "nix-community-nixops-datadog": {
             "url": "https://github.com/nix-community/nixops-datadog.git"
@@ -266,11 +368,14 @@
         "nix-community-nixops-vbox": {
             "url": "https://github.com/nix-community/nixops-vbox.git"
         },
-        "nix-community-nixops_hcloud": {
-            "url": "https://github.com/nix-community/nixops_hcloud.git"
+        "nix-community-nixos-gen-config": {
+            "url": "https://github.com/nix-community/nixos-gen-config.git"
         },
         "nix-community-nixos-generators": {
             "url": "https://github.com/nix-community/nixos-generators.git"
+        },
+        "nix-community-nixos-images": {
+            "url": "https://github.com/nix-community/nixos-images.git"
         },
         "nix-community-nixos-install-scripts": {
             "url": "https://github.com/nix-community/nixos-install-scripts.git"
@@ -278,11 +383,11 @@
         "nix-community-nixos-modules-contrib": {
             "url": "https://github.com/nix-community/nixos-modules-contrib.git"
         },
-        "nix-community-nixpkgs": {
-            "url": "https://github.com/nix-community/nixpkgs.git"
-        },
         "nix-community-nixpkgs-fmt": {
             "url": "https://github.com/nix-community/nixpkgs-fmt.git"
+        },
+        "nix-community-nixpkgs-lint": {
+            "url": "https://github.com/nix-community/nixpkgs-lint.git"
         },
         "nix-community-nixpkgs-pytools": {
             "url": "https://github.com/nix-community/nixpkgs-pytools.git"
@@ -290,8 +395,20 @@
         "nix-community-nixpkgs-swh": {
             "url": "https://github.com/nix-community/nixpkgs-swh.git"
         },
+        "nix-community-nixpkgs-terraform-providers-bin": {
+            "url": "https://github.com/nix-community/nixpkgs-terraform-providers-bin.git"
+        },
+        "nix-community-nixpkgs-wayland": {
+            "url": "https://github.com/nix-community/nixpkgs-wayland.git"
+        },
+        "nix-community-nixpkgs.lib": {
+            "url": "https://github.com/nix-community/nixpkgs.lib.git"
+        },
         "nix-community-nixt": {
             "url": "https://github.com/nix-community/nixt.git"
+        },
+        "nix-community-npmlock2nix": {
+            "url": "https://github.com/nix-community/npmlock2nix.git"
         },
         "nix-community-nur-combined": {
             "url": "https://github.com/nix-community/nur-combined.git"
@@ -308,17 +425,17 @@
         "nix-community-pip2nix": {
             "url": "https://github.com/nix-community/pip2nix.git"
         },
-        "nix-community-pipewire-to-json": {
-            "url": "https://github.com/nix-community/pipewire-to-json.git"
-        },
         "nix-community-pnpm2nix": {
             "url": "https://github.com/nix-community/pnpm2nix.git"
         },
         "nix-community-poetry2nix": {
             "url": "https://github.com/nix-community/poetry2nix.git"
         },
-        "nix-community-pypi2nix": {
-            "url": "https://github.com/nix-community/pypi2nix.git"
+        "nix-community-pruned-racket-catalog": {
+            "url": "https://github.com/nix-community/pruned-racket-catalog.git"
+        },
+        "nix-community-pynixutil": {
+            "url": "https://github.com/nix-community/pynixutil.git"
         },
         "nix-community-pypi2nix-overrides": {
             "url": "https://github.com/nix-community/pypi2nix-overrides.git"
@@ -329,8 +446,14 @@
         "nix-community-redoxpkgs": {
             "url": "https://github.com/nix-community/redoxpkgs.git"
         },
+        "nix-community-review-bot": {
+            "url": "https://github.com/nix-community/review-bot.git"
+        },
         "nix-community-rfc55": {
             "url": "https://github.com/nix-community/rfc55.git"
+        },
+        "nix-community-rnix-hashes": {
+            "url": "https://github.com/nix-community/rnix-hashes.git"
         },
         "nix-community-rnix-lsp": {
             "url": "https://github.com/nix-community/rnix-lsp.git"
@@ -338,11 +461,11 @@
         "nix-community-rnix-parser": {
             "url": "https://github.com/nix-community/rnix-parser.git"
         },
-        "nix-community-setup.nix": {
-            "url": "https://github.com/nix-community/setup.nix.git"
+        "nix-community-talon-nix": {
+            "url": "https://github.com/nix-community/talon-nix.git"
         },
-        "nix-community-test-fork-behaviour": {
-            "url": "https://github.com/nix-community/test-fork-behaviour.git"
+        "nix-community-templates": {
+            "url": "https://github.com/nix-community/templates.git"
         },
         "nix-community-todomvc-nix": {
             "url": "https://github.com/nix-community/todomvc-nix.git"
@@ -350,20 +473,17 @@
         "nix-community-travis-build": {
             "url": "https://github.com/nix-community/travis-build.git"
         },
+        "nix-community-trustix": {
+            "url": "https://github.com/nix-community/trustix.git"
+        },
         "nix-community-vagrant-nixos-plugin": {
             "url": "https://github.com/nix-community/vagrant-nixos-plugin.git"
-        },
-        "nix-community-vgo2nix": {
-            "url": "https://github.com/nix-community/vgo2nix.git"
         },
         "nix-community-vscode-nix-ide": {
             "url": "https://github.com/nix-community/vscode-nix-ide.git"
         },
         "nix-community-wiki": {
             "url": "https://github.com/nix-community/wiki.git"
-        },
-        "nix-community-yarn2nix": {
-            "url": "https://github.com/nix-community/yarn2nix.git"
         }
     },
     "vcs-config": {

--- a/services/hound/update-hound.py
+++ b/services/hound/update-hound.py
@@ -5,13 +5,15 @@ import requests
 import json
 from pprint import pprint
 
-blacklist = [
-    'https://github.com/NixOS/nixos.git',
-    'https://github.com/NixOS/systemd.git',
-    'https://github.com/NixOS/docker.git',
-    'https://github.com/NixOS/nixpkgs-channels.git',
-    'https://github.com/NixOS/nixops-dashboard.git',
-    'https://github.com/NixOS/nixos-foundation.git',
+allowed_forks = [
+    'nix-community/acpi_call',
+    'nix-community/bundix',
+    'nix-community/luarocks-nix',
+    'nix-community/nix-doom-emacs',
+    'nix-community/nix-straight.el',
+    'nix-community/travis-build',
+    'nix-community/vagrant-nixos-plugin',
+    'NixOS/calamares-nixos-extensions',
 ];
 
 def all_for_org(org):
@@ -34,7 +36,8 @@ def all_for_org(org):
                 'url': repo['clone_url'],
             }
             for repo in repos
-            if repo['clone_url'] not in blacklist
+            if repo['archived'] == False
+            if repo['fork'] == False or repo['full_name'] in allowed_forks
         })
 
     return resp


### PR DESCRIPTION
<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->

~~With this we do lose a few repos, e.g. https://github.com/nix-community/bundix, https://github.com/nix-community/luarocks-nix but defaulting to not including forks seems sensible. Perhaps could include them via an allowlist instead?~~

Switched to allowing some forks.