### PR TITLE
build02: remove hercules

### DIFF
--- a/build02/configuration.nix
+++ b/build02/configuration.nix
@@ -5,7 +5,6 @@
     ../roles/common.nix
     ../roles/hardware/hetzner-amd.nix
     ../roles/hetzner-network.nix
-    ../roles/hercules-ci
     ../roles/nginx.nix
     ../roles/raid.nix
     ../roles/remote-builder/aarch64-build04.nix


### PR DESCRIPTION
<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->

Might save a bit of memory, don't really need it on both build02 and build03. 

Also aligns the hercules and hydra config (build03/build04).