### PR TITLE
build02: correct for alphabetic bias in updates

### DIFF
--- a/build02/nixpkgs-update.nix
+++ b/build02/nixpkgs-update.nix
@@ -99,7 +99,7 @@ let
         mkfifo $pipe || true
       fi
 
-      ${cmd} > $pipe
+      ${cmd} | sort -R > $pipe
     '';
   };
 


### PR DESCRIPTION
I am very ignorant about how all this infrastructure works, so I have no idea if I'm suggesting the right thing here.

However, looking at https://r.ryantm.com/log/, it seems that packages earlier in the alphabet get updated more frequently than packages later in the alphabet. I imagine something like the following is happening:
* Each of the fetchers in this file is outputting an alphabetical list of packages to update to the FIFO.
* The workers are processing those packages in order.
* Before the workers finish processing the entire queue, something happens to the infrastructure (a nixpkgs update, maybe?) that respawns everything.
* The workers start again at the beginning of the alphabet.

I wanted to make sure I wasn't imagining things, so I collected some data. Here's my quick-and-dirty JavaScript that you can run in a browser console on https://r.ryantm.com/log/.

```js
const pre = document.getElementsByTagName('pre')[0];
const cutoff = new Date('2022 Oct 1'); // stuff changes, let's just look at packages that have been updated somewhat recently
const buckets = {};
for (let i = 0; i < pre.childNodes.length; i += 2) {
  let n1 = pre.childNodes[i];
  let n2 = pre.childNodes[i + 1];
  let d = new Date(n2.textContent.slice(0, -10).replace(/-/g, '/'));
  if (d >= cutoff) {
    let letter = n1.textContent[0];
    if (!(letter in buckets)) {
      buckets[letter] = [];
    }
    buckets[letter].push(d);
  }
}
console.log(Object.fromEntries(Object.entries(buckets).map(([k, x]) => [k, new Date(x.map(y => y.getTime()).reduce((y, z) => y + z)/x.length).toGMTString()])));
```

Result (right now)—of the packages logged at all since Oct 1, the average time a package was last logged, grouping packages by their first letter:
```
A: "Fri, 16 Dec 2022 16:24:00 GMT"
B: "Sat, 17 Dec 2022 01:07:00 GMT"
C: "Sat, 10 Dec 2022 12:45:13 GMT"
E: "Fri, 16 Dec 2022 20:37:00 GMT"
L: "Tue, 13 Dec 2022 10:15:00 GMT"
M: "Sat, 17 Dec 2022 01:08:00 GMT"
O: "Mon, 05 Dec 2022 17:10:00 GMT"
P: "Sat, 17 Dec 2022 01:08:00 GMT"
S: "Tue, 18 Oct 2022 02:14:50 GMT"
V: "Sat, 01 Oct 2022 07:31:00 GMT"
_: "Fri, 09 Dec 2022 13:48:37 GMT"
a: "Thu, 08 Dec 2022 13:51:35 GMT"
b: "Mon, 05 Dec 2022 15:24:09 GMT"
c: "Wed, 07 Dec 2022 04:13:19 GMT"
d: "Mon, 05 Dec 2022 12:12:21 GMT"
e: "Mon, 05 Dec 2022 11:47:32 GMT"
f: "Sat, 03 Dec 2022 19:13:30 GMT"
g: "Fri, 02 Dec 2022 18:29:16 GMT"
h: "Mon, 28 Nov 2022 14:26:02 GMT"
i: "Fri, 25 Nov 2022 19:52:40 GMT"
j: "Mon, 21 Nov 2022 22:19:20 GMT"
k: "Fri, 25 Nov 2022 11:03:08 GMT"
l: "Mon, 21 Nov 2022 15:45:17 GMT"
m: "Sun, 04 Dec 2022 18:28:00 GMT"
n: "Thu, 01 Dec 2022 19:26:17 GMT"
o: "Sun, 04 Dec 2022 06:47:10 GMT"
p: "Thu, 08 Dec 2022 08:10:27 GMT"
q: "Mon, 28 Nov 2022 09:23:03 GMT"
r: "Mon, 31 Oct 2022 23:48:31 GMT"
s: "Wed, 09 Nov 2022 18:25:24 GMT"
t: "Tue, 08 Nov 2022 01:50:53 GMT"
u: "Wed, 09 Nov 2022 10:03:53 GMT"
v: "Tue, 08 Nov 2022 18:40:30 GMT"
w: "Sat, 12 Nov 2022 05:44:31 GMT"
x: "Mon, 17 Oct 2022 08:14:02 GMT"
y: "Sun, 13 Nov 2022 06:59:46 GMT"
z: "Wed, 16 Nov 2022 23:13:41 GMT"
```

As you can see, things start to look pretty stale around the 'r's.

My proposed solution is to randomize the outputs of the fetchers. Might help? Seems easy enough to try.

I have not tested this infrastructure code; I'd have no idea where to begin.