### PR TITLE
treefmt: remove shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ Thanks to Cachix for sponsoring our binary cache!
 ## File hierarchy
 
 * ./build\d+ - build machines
-* ./ci.sh - What is executed by CI
 * ./deploy - Deploy script
 * ./roles - shared NixOS configuration modules
 * ./services - single instances of NixOS services

--- a/ci.sh
+++ b/ci.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-# Run this command to reproduce CI
-set -euo pipefail
-cd "$(dirname "$0")"
-nix-build --no-out-link ci.nix

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -25,20 +25,6 @@
           includes = [ "*.nix" ];
           excludes = [ "nix/sources.nix" ];
         };
-        shell = {
-          command = "sh";
-          options = [
-            "-eucx"
-            ''
-              # First shellcheck
-              ${pkgs.lib.getExe pkgs.shellcheck} --external-sources --source-path=SCRIPTDIR "$@"
-              # Then format
-              ${pkgs.lib.getExe pkgs.shfmt} -i 2 -s -w "$@"
-            ''
-            "--"
-          ];
-          includes = [ "*.sh" ];
-        };
 
         python = {
           command = "sh";


### PR DESCRIPTION
<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->

`ci.sh` seems a bit redundant. (also needs aarch64 and x86_64 to build)

Removing shell from treefmt as now it isn't needed for anything in the repo.