### PR TITLE
docs/_config.yml: disable description

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,7 @@
 theme: jekyll-theme-primer
 url: "https://nix-community.org"
 title: nix-community
+description:
 
 # see https://github.com/github/pages-gem/blob/754a725e4766d4329bb1dd0e07c638a045ad2c04/lib/github-pages/plugins.rb#L6-L42
 plugins:


### PR DESCRIPTION
currently this is show the description from the infra repo

<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->
