### PR TITLE
change to PR only workflow 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,2 @@
-"merge with bors":
-  - terraform/**/*
-
 "terraform":
   - terraform/**/*

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -108,17 +108,20 @@ branches:
     # Branch Protection settings. Set to null to disable
     protection:
       # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+
+      # these settings are the same as manually enabling "Require a pull request before merging" but not setting any other restrictions
       required_pull_request_reviews:
         # # The number of approvals required. (1-6)
-        # required_approving_review_count: 1
+        required_approving_review_count: 0
         # # Dismiss approved reviews automatically when a new commit is pushed.
-        # dismiss_stale_reviews: true
+        dismiss_stale_reviews: false
         # # Blocks merge until code owners have reviewed.
-        # require_code_owner_reviews: true
+        require_code_owner_reviews: false
         # # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
         # dismissal_restrictions:
         #   users: []
         #   teams: []
+        require_last_push_approval: false
       # Required. Require status checks to pass before merging. Set to null to disable
       required_status_checks:
         # Required. Require branches to be up to date before merging.
@@ -129,7 +132,7 @@ branches:
           - ci/hercules/effects
           - ci/hercules/evaluation
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: false
+      enforce_admins: true
       # Disabled for bors to work
       required_linear_history: false
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -82,14 +82,14 @@ milestones:
 # See https://docs.github.com/en/rest/reference/repos#add-a-repository-collaborator for available options
 collaborators:
   # - username: numtide-bot
-    # Note: `permission` is only valid on organization-owned repositories.
-    # The permission to grant the collaborator. Can be one of:
-    # * `pull` - can pull, but not push to or administer this repository.
-    # * `push` - can pull and push, but not administer this repository.
-    # * `admin` - can pull, push and administer this repository.
-    # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
-    # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.
-    # permission: push
+  # Note: `permission` is only valid on organization-owned repositories.
+  # The permission to grant the collaborator. Can be one of:
+  # * `pull` - can pull, but not push to or administer this repository.
+  # * `push` - can pull and push, but not administer this repository.
+  # * `admin` - can pull, push and administer this repository.
+  # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
+  # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.
+  # permission: push
 
 # See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
 teams:
@@ -134,6 +134,6 @@ branches:
       required_linear_history: false
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
       restrictions:
-        apps: [ "bors", "mergify" ]
+        apps: ["bors", "mergify"]
         users: []
         teams: []

--- a/.github/workflows/flake-updates-nixpkgs-update.yml
+++ b/.github/workflows/flake-updates-nixpkgs-update.yml
@@ -1,0 +1,19 @@
+name: "Update flakes - nixpkgs-update"
+on:
+  repository_dispatch:
+  workflow_dispatch:
+jobs:
+  createPullRequest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v15
+        with:
+          inputs: nixpkgs-update


### PR DESCRIPTION
<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->

cc @adisbladis @Mic92 @ryantm @zimbatm 


@ryantm Is the action a good enough workaround for you not being able to push `nixpkgs-update` updates to master? Can run it manually on github or via cli.

https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow?tool=webui

```
export GITHUB_TOKEN=<token with repo write access>
gh workflow run flake-updates-nixpkgs-update.yml --repo nix-community/infra
```