### PR TITLE
terraform/cloudflare: add nix-community.org verification for github

### DIFF
--- a/terraform/cloudflare_nix-community_org.tf
+++ b/terraform/cloudflare_nix-community_org.tf
@@ -117,6 +117,13 @@ resource "cloudflare_record" "nix-community-org-apex-TXT" {
   type    = "TXT"
 }
 
+resource "cloudflare_record" "nix-community-org-github-challenge-TXT" {
+  zone_id = local.nix_community_org_zone_id
+  name    = "_github-challenge-nix-community-org"
+  value   = "2eee7c1945"
+  type    = "TXT"
+}
+
 resource "cloudflare_record" "nix-community-org-github-pages-challenge-TXT" {
   zone_id = local.nix_community_org_zone_id
   name    = "_github-pages-challenge-nix-community.nix-community.org."


### PR DESCRIPTION
<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->

This gives the domain the verified badge on https://github.com/nix-community.

https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-organization-settings/verifying-or-approving-a-domain-for-your-organization
