### PR TITLE
terraform/terraform wrapper

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -31,16 +31,16 @@ jobs:
             accept-flake-config = true
       - name: init
         if: steps.changes.outputs.terraform == 'true'
-        run: nix develop -c ./terraform/deploy terraform init -input=false
+        run: nix develop -c ./terraform/terraform init -input=false
       - name: validate
         if: steps.changes.outputs.terraform == 'true'
-        run: nix develop -c ./terraform/deploy terraform validate
+        run: nix develop -c ./terraform/terraform validate
       - name: fmt
         if: steps.changes.outputs.terraform == 'true'
-        run: nix develop -c ./terraform/deploy terraform fmt -check
+        run: nix develop -c ./terraform/terraform fmt -check
       - name: plan
         if: steps.changes.outputs.terraform == 'true' && github.ref == 'refs/heads/trying'
-        run: nix develop -c ./terraform/deploy terraform plan -input=false
+        run: nix develop -c ./terraform/terraform plan -input=false
       - name: apply
         if: steps.changes.outputs.terraform == 'true' && github.ref == 'refs/heads/staging'
-        run: nix develop -c ./terraform/deploy terraform apply -auto-approve -input=false
+        run: nix develop -c ./terraform/terraform apply -auto-approve -input=false

--- a/terraform/terraform
+++ b/terraform/terraform
@@ -4,6 +4,6 @@ set -euo pipefail
 pushd "$(dirname "$0")" >/dev/null
 
 # terraform cloud without the remote execution part
-TF_FORCE_LOCAL_BACKEND="1" sops exec-env secrets.yaml "${*@Q}"
+TF_FORCE_LOCAL_BACKEND="1" sops exec-env secrets.yaml "terraform ${*@Q}"
 
 popd >/dev/null


### PR DESCRIPTION
Renamed the wrapper because all the usages of ./terraform/deploy were
invoking terraform. I also fixed an escaping issue that I encountered
when running `./terraform import 'some.resource["xxx"]' ID`

<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->
