### PR TITLE
build04: switch to systemd-boot

### DIFF
--- a/build04/configuration.nix
+++ b/build04/configuration.nix
@@ -1,4 +1,3 @@
-{ ... }:
 {
   imports = [
     ./hardware-configuration.nix
@@ -12,13 +11,8 @@
   # disable kvm/nixos-tests
   nix.settings.system-features = [ "big-parallel" ]; # sync with roles/remote-builder/aarch64-build04.nix
 
-  # we use grub because systemd-boot sometimes fail on aarch64/EFI
-  # XXX check if this is still an issue?
-  boot.loader.grub.devices = [ "nodev" ];
-  boot.loader.grub.enable = true;
-  boot.loader.grub.efiSupport = true;
-  boot.loader.grub.version = 2;
-  boot.loader.efi.canTouchEfiVariables = true;
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = false;
 
   # Make it easier to recover via serial console in case something goes wrong.
   services.getty.autologinUser = "root";


### PR DESCRIPTION
cc @zowoq
I was greeted by a EDK2 EFI shell and had to boot grub manually.
Systemd-boot meanwhile seems to work fine and also installs a default boot loader path that would work even if efivars is not set.
bors merge