### PR TITLE
.github/settings.yml: rename team, infra -> admin

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -93,7 +93,7 @@ collaborators:
 
 # See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
 teams:
-  - name: infra
+  - name: admin
     # The permission to grant the team. Can be one of:
     # * `pull` - can pull, but not push to or administer this repository.
     # * `push` - can pull and push, but not administer this repository.


### PR DESCRIPTION
<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->

https://github.com/orgs/nix-community/teams/infra

https://github.com/nix-community/infra#nix-community-administrators

I was going to rename `@nix-community/infra` to better match the role of this team.

cc @nix-community/infra