### PR TITLE
remove nixpkgs-update-pypi-releases

### DIFF
--- a/build02/nixpkgs-update.nix
+++ b/build02/nixpkgs-update.nix
@@ -1,6 +1,5 @@
 { nixpkgs-update
 , nixpkgs-update-github-releases
-, nixpkgs-update-pypi-releases
 }:
 { pkgs, lib, config, ... }:
 let
@@ -76,7 +75,6 @@ let
     # API_TOKEN is used by nixpkgs-update-github-releases
     environment.API_TOKEN_FILE = "/var/lib/nixpkgs-update/github_token_with_username.txt";
     # Used by nixpkgs-update-github-releases to install python dependencies
-    # Used by nixpkgs-update-pypi-releases
     environment.NIX_PATH = "nixpkgs=/var/cache/nixpkgs-update/fetcher/nixpkgs";
     environment.XDG_CACHE_HOME = "/var/cache/nixpkgs-update/fetcher/";
 
@@ -143,8 +141,6 @@ in
 
   systemd.services.nixpkgs-update-fetch-repology = mkFetcher "${nixpkgs-update-bin} fetch-repology";
   systemd.services.nixpkgs-update-fetch-updatescript = mkFetcher "${pkgs.nix}/bin/nix eval --raw -f ${./packages-with-update-script.nix}";
-  # turning off this fetcher, because I think it is covered by the updateScript one
-  #systemd.services.nixpkgs-update-fetch-pypi = mkFetcher "grep -rl $XDG_CACHE_HOME/nixpkgs -e buildPython | grep default | ${nixpkgs-update-pypi-releases'} --nixpkgs=/var/cache/nixpkgs-update/fetcher/nixpkgs";
   systemd.services.nixpkgs-update-fetch-github = mkFetcher nixpkgs-update-github-releases';
 
   systemd.services.nixpkgs-update-worker1 = mkWorker "worker1";

--- a/flake.lock
+++ b/flake.lock
@@ -115,22 +115,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-update-pypi-releases": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1628829542,
-        "narHash": "sha256-KcCJgTuBh9HITE2mpSHQA36BiFtGW7sLWKVS29biwgM=",
-        "owner": "ryantm",
-        "repo": "nixpkgs-update-pypi-releases",
-        "rev": "56afe60a7fd7ee7f5dac5feeea8a983aba759997",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ryantm",
-        "repo": "nixpkgs-update-pypi-releases",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1672428209,
@@ -173,7 +157,6 @@
         "nixpkgs": "nixpkgs",
         "nixpkgs-update": "nixpkgs-update",
         "nixpkgs-update-github-releases": "nixpkgs-update-github-releases",
-        "nixpkgs-update-pypi-releases": "nixpkgs-update-pypi-releases",
         "nur-update": "nur-update",
         "sops-nix": "sops-nix",
         "srvos": "srvos",

--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,6 @@
     nixpkgs-update.inputs.mmdoc.follows = "";
     nixpkgs-update-github-releases.url = "github:ryantm/nixpkgs-update-github-releases";
     nixpkgs-update-github-releases.flake = false;
-    nixpkgs-update-pypi-releases.url = "github:ryantm/nixpkgs-update-pypi-releases";
-    nixpkgs-update-pypi-releases.flake = false;
 
     nur-update.url = "github:nix-community/nur-update";
     nur-update.inputs.nixpkgs.follows = "nixpkgs";
@@ -98,7 +96,6 @@
                       (inputs)
                       nixpkgs-update
                       nixpkgs-update-github-releases
-                      nixpkgs-update-pypi-releases
                       ;
                   })
                   ./build02/configuration.nix


### PR DESCRIPTION
86f4428fe017140f2b4c849cda2cd6c26a9ff705

has been disabled for a couple of months now

<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->
