### PR TITLE
build03: disable hydra

### DIFF
--- a/build03/configuration.nix
+++ b/build03/configuration.nix
@@ -16,7 +16,7 @@
     ../roles/remote-builder/aarch64-build04.nix
 
     ../services/hound
-    ../services/hydra
+    #../services/hydra
   ];
 
   # /boot is a mirror raid


### PR DESCRIPTION
post-build-hook is failing and blocking builds that are scheduled on build03

<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->
