### PR TITLE
Revert "build02/nixpkgs-update: enable another worker"

### DIFF
--- a/build02/nixpkgs-update.nix
+++ b/build02/nixpkgs-update.nix
@@ -145,8 +145,8 @@ in
 
   systemd.services.nixpkgs-update-worker1 = mkWorker "worker1";
   systemd.services.nixpkgs-update-worker2 = mkWorker "worker2";
-  systemd.services.nixpkgs-update-worker3 = mkWorker "worker3";
   # Too many workers cause out-of-memory.
+  #systemd.services.nixpkgs-update-worker3 = mkWorker "worker3";
   #systemd.services.nixpkgs-update-worker4 = mkWorker "worker4";
 
   systemd.tmpfiles.rules = [


### PR DESCRIPTION
uses too much memory

This reverts commit e1fa02c23fa1e166064530576b1baeb522f55223.

<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->
