### PR TITLE
remove post-build-hook, switch to cachix watch-store

### DIFF
--- a/build03/configuration.nix
+++ b/build03/configuration.nix
@@ -12,6 +12,7 @@
   imports = [
     ../roles/common.nix
     ../roles/hercules-ci
+    ../roles/watch-store.nix
     ../roles/zfs-raid.nix
     ../roles/remote-builder/aarch64-build04.nix
 

--- a/roles/nix-community-cache/secrets.yaml
+++ b/roles/nix-community-cache/secrets.yaml
@@ -1,4 +1,5 @@
 nix-community-cachix: ENC[AES256_GCM,data:tGMaYSBnhZ9idMV7DGzUfR1Zzk70syR8f4DSkrO65XcYUvoS4tcaVXr4l6PzDAFetkgU92a/kkIrEMZ9tZZZGHMvmCteGObH2BgF6k57NdozNnkXsI4ZhltATu5tpwzI+DUFgtpAXPEVYY6DRDlUATrt8SKJ2JuI4JtpIHpPi0noS/WpBfsphOUQ/7epTtABLpyDb0EOXisvkPLjDIKwfNDE+dOHO61aN8zS14QhelRIfJUSj7BwVFWbaseLKmq5ZIDAFK5s/FSgToi4Bj/YYVrTo23RH8wvhYOelSNcAWW/wotMZ5u/pklTytytLC41DhyFXU54k/UEorfVMHMnLAlujDoBs/9oV+M18Jcs0qV7c1utzjwoGlYhxV7zV/QvJ2zuMyDtszK0twcL8BjUSpsy+W/sR3kpGBKzjt1oNteTlz0YvIXlxg/Yn63qGr2/HzZlNd9rygMnLhTf7VO4Su2AB4GLXI7ljgQdqM7AREuAgE5J0hHE82fRalBsZcK34QGEFVKN4mzybcK4HO70yUQY4o5cOc7R5DHvEJmukjjJclm/,iv:N/yKtyd56YpdpNEe92g9Eml8gYR9x5pBT66U5p20Rzw=,tag:HCAJSqQ3Wq5SnZDwdryN1Q==,type:str]
+watch-store-token: ENC[AES256_GCM,data:ectFQuDP3HWW+QVBvxtQ6PeBVuyyi6NVFpL8E1OvMfYfCvu3XQQppEAeqbdKhns6dHD2NZOz6Hts3hQC7ob936ss5nQrIAcfM/9JRcrC8E5yYCtllHuF8MSfeq7CGRWtzjWhLtJrnMowuBQVr1Oqh4Twac2fdeRH7NnC9DJZiMht94iHk+nW6j3jpkpbHu/3+oZxSgGlLaedvpS8noKtr2XNuxM=,iv:o5XHaEjJxiq4gU7pmHHlr8Ep1stDGq23CSBHPC3RCdM=,tag:1bOdCHl8HGrxzts5dZQ4IQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -77,8 +78,8 @@ sops:
             bHdjYjdpMzVXZ0E0TVF4VWV6ZVd4RmsKjkx/AjiH1c6BnjAhPwQJAiuFto8KQ5ep
             fXyjt2rQCZy5snOEiwCUWFdZvLmrtoZlUw7dYmUbq4IEygkTlSRo0g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-09-25T19:43:46Z"
-    mac: ENC[AES256_GCM,data:ZQibKAevbsldaAIjzoZ4/zzWdCLaGHKMzBU7zre6DnE+9UF3vpa+VWfTPCs7ovqKkWJUsTiyyg8JxMeF3ivFnXRzrbzeX5EZRAqlKQJHXAp5ruWDJL5Zaw3dWMVM70MGJDOsZdws5tJUu8jbZN5nYX+yjw1zDIfb1Gho7sfYg48=,iv:VDP2iWxiFy+4vTQd5DKMNpMFAWrfwKKaGfZos+Y5l3U=,tag:wo8a27b6hWkL85e+IIm58Q==,type:str]
+    lastmodified: "2023-04-11T22:25:24Z"
+    mac: ENC[AES256_GCM,data:wW9ilTzHroIfRARpTFdWJTgeTVxc6ike59vik6+kWQ88LQ+FOEivRidcN6GBs11CZIrPZ0bdIdGoBAU3ITCBFT86kzZarXp5UA9gldsHHHy4AJGnf8AtS+xy2pttHHwcal8xG6xjMM9mON0GTsSZT1DUCWBXjTZgfO3Ffr6D8q0=,iv:3/CjqY8GoIzJXfhJcArxHeS+EFMWs7LrMDGeZIcl7MA=,tag:A0qqPDNYfMcivyTqNiA45g==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.1
+    version: 3.7.3

--- a/roles/watch-store.nix
+++ b/roles/watch-store.nix
@@ -1,0 +1,12 @@
+{ config, pkgs, ... }:
+
+{
+  sops.secrets.watch-store-token.sopsFile = ./nix-community-cache/secrets.yaml;
+
+  services.cachix-watch-store = {
+    enable = true;
+    cacheName = "nix-community";
+    cachixTokenFile = config.sops.secrets.watch-store-token.path;
+    package = pkgs.haskellPackages.cachix_1_3_3;
+  };
+}

--- a/services/hydra/default.nix
+++ b/services/hydra/default.nix
@@ -3,21 +3,6 @@ with lib; let
   cfg = config;
 
   hydraPort = 3000;
-
-  upload-to-cachix = pkgs.writeScriptBin "upload-to-cachix" ''
-    #!/bin/sh
-    set -eu
-    set -f # disable globbing
-
-    # skip push if the declarative job spec
-    OUT_END=$(echo ''${OUT_PATHS: -10})
-    if [ "$OUT_END" == "-spec.json" ]; then
-      exit 0
-    fi
-
-    export HOME=/root
-    exec ${pkgs.haskellPackages.cachix_1_3_3}/bin/cachix -c ${config.sops.secrets.nix-community-cachix.path} push nix-community $OUT_PATHS > /tmp/hydra_cachix 2>&1
-  '';
 in
 {
   options.services.hydra = {
@@ -46,7 +31,6 @@ in
     nix.extraOptions = ''
       builders-use-substitutes = true
       allowed-uris = https://github.com/nix-community/ https://github.com/NixOS/
-      post-build-hook = ${upload-to-cachix}/bin/upload-to-cachix
     '';
 
     nixpkgs.config = {
@@ -61,7 +45,6 @@ in
         ];
     };
 
-    sops.secrets.nix-community-cachix.sopsFile = ../../roles/nix-community-cache/secrets.yaml;
     sops.secrets.id_buildfarm = { };
 
     # delete build logs older than 30 days

--- a/services/hydra/default.nix
+++ b/services/hydra/default.nix
@@ -28,10 +28,10 @@ in
     # hydra-queue-runner needs to read this key for remote building
     sops.secrets.id_buildfarm.owner = "hydra-queue-runner";
 
-    nix.extraOptions = ''
-      builders-use-substitutes = true
-      allowed-uris = https://github.com/nix-community/ https://github.com/NixOS/
-    '';
+    nix.settings.allowed-uris = [
+      "https://github.com/nix-community/"
+      "https://github.com/NixOS/"
+    ];
 
     nixpkgs.config = {
       whitelistedLicenses = with lib.licenses; [


### PR DESCRIPTION
<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->

watch-store seems to be more efficient than the hook.

https://github.com/cachix/cachix/blob/master/cachix/CHANGELOG.md#13---2023-03-06

with >=1.3 it defaults to 8 jobs
