### PR TITLE
flake: add nix-community/flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,16 @@
+# This file provides backward compatibility to nix < 2.4 clients
+{ system ? builtins.currentSystem }:
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+  root = lock.nodes.${lock.root};
+  inherit (lock.nodes.${root.inputs.flake-compat}.locked) owner repo rev narHash;
+
+  flake-compat = fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  };
+
+  flake = import flake-compat { inherit system; src = ./.; };
+in
+flake.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -110,6 +110,21 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1688025799,
+        "narHash": "sha256-ktpB4dRtnksm9F5WawoIkEneh1nrEvuxb5lJFt1iOyw=",
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "rev": "8bf105319d44f6b9f0d764efa4fdef9f1cc9ba1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -248,6 +263,7 @@
         "comin": "comin",
         "disko": "disko",
         "empty": "empty",
+        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
     disko.inputs.nixpkgs.follows = "nixpkgs";
     disko.url = "github:nix-community/disko";
     empty.url = "github:nix-systems/empty";
+    flake-compat.url = "github:nix-community/flake-compat";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
     flake-parts.url = "github:hercules-ci/flake-parts";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
It's easier to be able to fall back to the old cli sometimes.

I'm fine with not adding it if anyone is 👎 .

cc @nix-community/admin 

<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->
