### PR TITLE
treefmt: add deadnix

### DIFF
--- a/treefmt.nix
+++ b/treefmt.nix
@@ -12,6 +12,8 @@
       options = [
         "-eucx"
         ''
+          ${pkgs.lib.getExe pkgs.deadnix} --edit "$@"
+
           for i in "$@"; do
             ${pkgs.lib.getExe pkgs.statix} fix "$i"
           done


### PR DESCRIPTION
<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->

This mostly avoids my original objection to having deadnix enabled as now it isn't all or nothing. We can keep dead/commented out code without needing to disable the other nix formatters.

I think it's possible that the deadnix and nix formatters could conflict but that doesn't seem like too much of a hassle.