### PR TITLE
treefmt: flatten the config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,8 +60,9 @@
           inputs.treefmt-nix.flakeModule
           ./effect.nix
           ./shell.nix
-          ./treefmt.nix
         ];
+
+        perSystem.treefmt.imports = [ ./treefmt.nix ];
 
         flake.nixosConfigurations =
           let

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,54 +1,50 @@
-{
-  perSystem = { pkgs, ... }: {
-    treefmt = {
-      # Used to find the project root
-      projectRootFile = "flake.lock";
+{ pkgs, ... }: {
+  # Used to find the project root
+  projectRootFile = "flake.lock";
 
-      programs.hclfmt.enable = true;
+  programs.hclfmt.enable = true;
 
-      programs.prettier.enable = true;
+  programs.prettier.enable = true;
 
-      settings.formatter = {
-        nix = {
-          command = "sh";
-          options = [
-            "-eucx"
-            ''
-              for i in "$@"; do
-                ${pkgs.lib.getExe pkgs.statix} fix "$i"
-              done
+  settings.formatter = {
+    nix = {
+      command = "sh";
+      options = [
+        "-eucx"
+        ''
+          for i in "$@"; do
+            ${pkgs.lib.getExe pkgs.statix} fix "$i"
+          done
 
-              ${pkgs.lib.getExe pkgs.nixpkgs-fmt} "$@"
-            ''
-            "--"
-          ];
-          includes = [ "*.nix" ];
-          excludes = [
-            "nix/sources.nix"
-            # vendored from external source
-            "build02/packages-with-update-script.nix"
-          ];
-        };
+          ${pkgs.lib.getExe pkgs.nixpkgs-fmt} "$@"
+        ''
+        "--"
+      ];
+      includes = [ "*.nix" ];
+      excludes = [
+        "nix/sources.nix"
+        # vendored from external source
+        "build02/packages-with-update-script.nix"
+      ];
+    };
 
-        prettier = {
-          excludes = [
-            "secrets.yaml"
-          ];
-        };
+    prettier = {
+      excludes = [
+        "secrets.yaml"
+      ];
+    };
 
-        python = {
-          command = "sh";
-          options = [
-            "-eucx"
-            ''
-              ${pkgs.lib.getExe pkgs.ruff} --fix "$@"
-              ${pkgs.lib.getExe pkgs.python3.pkgs.black} "$@"
-            ''
-            "--" # this argument is ignored by bash
-          ];
-          includes = [ "*.py" ];
-        };
-      };
+    python = {
+      command = "sh";
+      options = [
+        "-eucx"
+        ''
+          ${pkgs.lib.getExe pkgs.ruff} --fix "$@"
+          ${pkgs.lib.getExe pkgs.python3.pkgs.black} "$@"
+        ''
+        "--" # this argument is ignored by bash
+      ];
+      includes = [ "*.py" ];
     };
   };
 }


### PR DESCRIPTION
By importing the config on the treefmt module level, it makes the config more flat, and also compatible with non-flake-parts users.

<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->
