### PR TITLE
build02/nixpkgs-update: pin cachix to 1.3.3

### DIFF
--- a/build02/nixpkgs-update.nix
+++ b/build02/nixpkgs-update.nix
@@ -12,7 +12,7 @@ let
     gnused
     curl
     getent # used by hub
-    cachix
+    haskellPackages.cachix_1_3_3
   ];
 
   nixpkgs-update-github-releases' = "${inputs.nixpkgs-update-github-releases}/main.py";


### PR DESCRIPTION
<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->

Same as https://github.com/nix-community/infra/pull/514, seems cachix has been causing the updates to fail as well.

cc @ryantm 