### PR TITLE
build04: set systemd-boot.configurationLimit

### DIFF
--- a/build04/configuration.nix
+++ b/build04/configuration.nix
@@ -12,6 +12,7 @@
   nix.settings.system-features = [ "big-parallel" ]; # sync with roles/remote-builder/aarch64-build04.nix
 
   boot.loader.systemd-boot.enable = true;
+  boot.loader.systemd-boot.configurationLimit = 3;
   boot.loader.efi.canTouchEfiVariables = false;
 
   # Make it easier to recover via serial console in case something goes wrong.


### PR DESCRIPTION
<!--
Pull requests from forks don't have automatic CI checks, an admin will need to trigger CI by posting a comment on the PR.
-->

`/boot` is starting to fill up again.