### PR TITLE
terraform: manage github org admins

### DIFF
--- a/terraform/flake.nix
+++ b/terraform/flake.nix
@@ -12,6 +12,7 @@
               p.cloudflare
               p.external
               p.gandi
+              p.github
               p.hydra
               p.null
               p.sops

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -1,0 +1,19 @@
+resource "github_membership" "owners" {
+  # make the bot an org owner but don't add it to the admin team
+  for_each = merge(local.admins, local.bot)
+  username = each.key
+  role     = "admin"
+}
+
+resource "github_team" "admin" {
+  name        = "admin"
+  description = "Organisation owners and people who have access to the infrastructure"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "admin" {
+  for_each = local.admins
+  role     = "maintainer"
+  team_id  = github_team.admin.id
+  username = each.key
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -7,4 +7,8 @@ locals {
     zimbatm    = "zimbatm@zimbatm.com"
     zowoq      = "zowoq.gh@gmail.com"
   }
+
+  bot = {
+    nix-infra-bot = "admin@nix-community.org"
+  }
 }

--- a/terraform/terraform_providers.tf
+++ b/terraform/terraform_providers.tf
@@ -6,6 +6,9 @@ terraform {
     gandi = {
       source = "go-gandi/gandi"
     }
+    github = {
+      source = "integrations/github"
+    }
     hydra = {
       source = "DeterminateSystems/hydra"
     }
@@ -29,6 +32,11 @@ provider "cloudflare" {
 provider "gandi" {
   key        = data.sops_file.nix-community.data["GANDI_KEY"]
   sharing_id = data.sops_file.nix-community.data["GANDI_SHARING_ID"]
+}
+
+provider "github" {
+  owner = "nix-community"
+  token = data.sops_file.secrets.data["GITHUB_TOKEN"]
 }
 
 provider "hydra" {


### PR DESCRIPTION
This'll make onboarding much simpler.

For managing non-admin members, repos, teams, etc I expect that we'd want to have that in a separate workspace or a separate repo.

I was going to do gitlab here as well but I'll do it in a separate PR.