### PR TITLE
docs: add security policy

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,7 @@
+To privately report a security issue with our projects, please send an email to:
+
+[admin@nix-community.org](mailto:admin@nix-community.org)
+
+We will usually respond within 48 hours.
+
+Thank you.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
       - FAQ: faq.md
       - administrators.md
   - contact.md
+  - security.md
 
 theme:
   name: material


### PR DESCRIPTION
Easier to keep it in this repo and have https://github.com/nix-community/.github/blob/master/SECURITY.md link to it.