### PR TITLE
shell: refactor, reduce size

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,21 +1,15 @@
 {
-  perSystem = { config, pkgs, ... }: {
+  perSystem = { pkgs, ... }: {
     devShells = {
       default = with pkgs; mkShellNoCC {
-        buildInputs = [
+        packages = [
           jq
+          python3.pkgs.deploykit
+          python3.pkgs.invoke
+          python3.pkgs.requests
+          rsync
           sops
           ssh-to-age
-          (python3.withPackages (
-            p: [
-              p.deploykit
-              p.invoke
-              p.requests
-            ]
-          ))
-          rsync
-          config.packages.pages.buildInputs
-          config.treefmt.build.wrapper
         ];
       };
     };

--- a/tasks.py
+++ b/tasks.py
@@ -169,6 +169,14 @@ git commit --amend -m "${commit}" -m "Terraform updates:" -m "${diff}"
         )
 
 
+@task
+def mkdocs(c):
+    """
+    Serve docs (mkdoc serve)
+    """
+    c.run("nix develop .#pages -c mkdocs serve")
+
+
 def get_hosts(hosts: str) -> List[DeployHost]:
     if hosts == "":
         return [DeployHost(f"build{n + 1:02d}.nix-community.org") for n in range(4)]


### PR DESCRIPTION
- drop treefmt, accessible via `nix fmt`

- drop mkdocs, accessible via `inv mkdocs`

this halves the size of the devshell