### PR TITLE
roles/auto-upgrade: separate reboot from upgrade

### DIFF
--- a/roles/auto-upgrade.nix
+++ b/roles/auto-upgrade.nix
@@ -1,7 +1,25 @@
+{ config, pkgs, ... }:
 {
   system.autoUpgrade.enable = true;
   system.autoUpgrade.flake = "github:nix-community/infra";
-  system.autoUpgrade.allowReboot = true;
   system.autoUpgrade.dates = "hourly";
   system.autoUpgrade.flags = [ "--option" "accept-flake-config" "true" "--option" "tarball-ttl" "0" ];
+
+  # adapted from https://github.com/NixOS/nixpkgs/blob/3428bdf3c93a7608615dddd44dec50c3df89b4be/nixos/modules/tasks/auto-upgrade.nix
+  systemd.services.reboot-after-update = {
+    restartIfChanged = false;
+    unitConfig.X-StopOnRemoval = false;
+    serviceConfig.Type = "oneshot";
+    script = ''
+      booted="$(${pkgs.coreutils}/bin/readlink /run/booted-system/{initrd,kernel,kernel-modules})"
+      built="$(${pkgs.coreutils}/bin/readlink /nix/var/nix/profiles/system/{initrd,kernel,kernel-modules})"
+      if [ "''${booted}" != "''${built}" ]; then
+        ${config.systemd.package}/bin/shutdown -r now
+      fi
+    '';
+    startAt = "0/6:00";
+  };
+  systemd.timers.reboot-after-update = {
+    timerConfig.RandomizedDelaySec = "6h";
+  };
 }


### PR DESCRIPTION
spread out reboots so every machine isn't offline at the same time