### PR TITLE
rfc: migrate to terragrunt project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ result-*
 # needed for treefmt
 !.github
 !.sops.yaml
+
+.direnv

--- a/tf/.envrc
+++ b/tf/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/tf/flake.lock
+++ b/tf/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1678780369,
+        "narHash": "sha256-D8wM0K1EkWLwbUu9fohC57+n89zC9qQ3hdC9Bys5GYw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1474943fd91fbe5567f7582acf568e0f999f4af1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tf/flake.nix
+++ b/tf/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "terraform devshell";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
+
+  outputs = { nixpkgs, self }: {
+    devShells = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ]
+      (system: {
+        default = with nixpkgs.legacyPackages.${system}; mkShellNoCC {
+          packages = [
+            terragrunt
+            (terraform.withPlugins (p: [
+              p.cloudflare
+              p.external
+              p.gandi
+              p.hydra
+              p.null
+              p.sops
+              p.tfe
+            ]))
+          ];
+        };
+      });
+  };
+}

--- a/tf/modules/nixos-wiki/main.tf
+++ b/tf/modules/nixos-wiki/main.tf
@@ -1,0 +1,15 @@
+# TODO: use openstack provider
+# https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_instance_v2
+
+#resource "openstack_compute_instance_v2" "instance_1" {
+#  name            = "basic"
+#  image_id        = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+#  flavor_id       = "3"
+#  key_pair        = "my_key_pair_name"
+#  security_groups = ["default"]
+#  user_data       = "#cloud-config\nhostname: instance_1.example.com\nfqdn: instance_1.example.com"
+#
+#  network {
+#    name = "my_network"
+#  }
+#}

--- a/tf/targets/nixos-wiki/terragrunt.hcl
+++ b/tf/targets/nixos-wiki/terragrunt.hcl
@@ -1,0 +1,7 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_path_to_repo_root()}tf/modules//nixos-wiki"
+}

--- a/tf/targets/terragrunt.hcl
+++ b/tf/targets/terragrunt.hcl
@@ -1,0 +1,29 @@
+terraform {
+  before_hook "reset old terraform state" {
+    commands = ["init"]
+    execute  = ["rm", "-f", ".terraform.lock.hcl"]
+  }
+}
+
+generate "terraform" {
+  path      = "terraform.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+terraform {
+  backend "remote" {
+    organization = "nix-community"
+    workspaces { name = "nix-community-${path_relative_to_include()}" }
+  }
+
+  required_providers {
+    cloudflare = { source = "cloudflare/cloudflare" }
+    external   = { source = "hashicorp/external" }
+    gandi     = { source = "go-gandi/gandi" }
+    hydra     = { source = "DeterminateSystems/hydra" }
+    null     = { source = "hashicorp/null" }
+    sops   = { source = "carlpett/sops" }
+    tfe     = { source = "hashicorp/tfe" }
+  }
+}
+EOF
+}


### PR DESCRIPTION
Advantages
- smaller targets that are easier to review and run faster
- re-usable provider configuration
- hooks in case we need to inject more complex secrets
- option to share information between targets through [dependencies](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#dependency)