### PR TITLE
docs: separate open collective and sponsors

### DIFF
--- a/docs/open-collective.md
+++ b/docs/open-collective.md
@@ -1,0 +1,1 @@
+<script src="https://opencollective.com/nix-community/banner.js"></script>

--- a/docs/sponsors.md
+++ b/docs/sponsors.md
@@ -1,9 +1,5 @@
 Thanks to all our sponsors.
 
-<object type="image/svg+xml" data="https://opencollective.com/nix-community/tiers/backers.svg?avatarHeight=55&width=500"></object>
-
-<object type="image/svg+xml" data="https://opencollective.com/nix-community/tiers/sponsors.svg?avatarHeight=55&width=500"></object>
-
 <!-- prettier-ignore-start -->
 |[<img src="https://raw.githubusercontent.com/cachix/docs.cachix.org/master/source/logo.png" width="200" alt="Cachix">](https://cachix.org)|[<img src="https://raw.githubusercontent.com/Gandi/.github/b1f21a402d9223c672476b41148429f538be5303/logos/black.svg" width="200" alt="Gandi">](https://www.gandi.net/)|
 |:-:|:-:|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 nav:
   - index.md
+  - Open Collective: open-collective.md
   - sponsors.md
   - Services:
       - continuous-integration.md


### PR DESCRIPTION
Seems the open collective svg stopped working as they aren't showing the backers and sponsors themselves:
<img width="768" alt="collective1" src="https://user-images.githubusercontent.com/59103226/236988243-f0922b07-6f20-4297-b9f8-fb183ccf7e14.png">

___

Switched to the js banner and moved the collective to a separate page to give it more space:

![collective2](https://user-images.githubusercontent.com/59103226/236988435-8f4d8934-00a2-410d-bfa2-a94832c043f7.png)
