### PR TITLE
.github/workflows/labels.yml: remove `repo-token`

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,5 +10,4 @@ jobs:
     steps:
       - uses: actions/labeler@v4
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true


### PR DESCRIPTION
defaults to `GITHUB_TOKEN`