### PR TITLE
flake: follow SrvOS's nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684106623,
-        "narHash": "sha256-Fxw/lWpx+Cr1sJQ+1msdPBnrRuO0ll1eT48+ym0oqDg=",
+        "lastModified": 1684077912,
+        "narHash": "sha256-HNuVjMGmSp3H1MM4ymne3r07ldIB54GgPQViUZjk5Wc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8fb30f6066a87a91c21241f1993a26ff57005486",
+        "rev": "57ace723895c43160e102cc126933d8b395391ea",
         "type": "github"
       },
       "original": {
@@ -83,7 +83,9 @@
     "nixpkgs-update": {
       "inputs": {
         "mmdoc": [],
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1681047420,
@@ -115,20 +117,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1672428209,
-        "narHash": "sha256-eejhqkDz2cb2vc5VeaWphJz8UXNuoNoM8/Op8eWv2tQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "293a28df6d7ff3dec1e61e37cc4ee6e6c0fb0847",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
     "nur-update": {
       "inputs": {
         "nixpkgs": [
@@ -154,7 +142,10 @@
         "disko": "disko",
         "flake-parts": "flake-parts",
         "hercules-ci-effects": "hercules-ci-effects",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "srvos",
+          "nixpkgs"
+        ],
         "nixpkgs-update": "nixpkgs-update",
         "nixpkgs-update-github-releases": "nixpkgs-update-github-releases",
         "nur-update": "nur-update",
@@ -186,9 +177,7 @@
     },
     "srvos": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1684109099,

--- a/flake.nix
+++ b/flake.nix
@@ -11,20 +11,24 @@
   ];
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
+    srvos.url = "github:numtide/srvos";
+
+    # use the version tested against srvos
+    nixpkgs.follows = "srvos/nixpkgs";
+
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+
     sops-nix.url = "github:Mic92/sops-nix";
     sops-nix.inputs.nixpkgs.follows = "nixpkgs";
     sops-nix.inputs.nixpkgs-stable.follows = "";
-    srvos.url = "github:numtide/srvos";
-    # actually not used when using the modules but than nothing ever will try to fetch this nixpkgs variant
-    srvos.inputs.nixpkgs.follows = "nixpkgs";
 
     nixpkgs-update.url = "github:ryantm/nixpkgs-update";
     nixpkgs-update.inputs.mmdoc.follows = "";
-    nixpkgs-update-github-releases.url = "github:ryantm/nixpkgs-update-github-releases";
+    nixpkgs-update.inputs.nixpkgs.follows = "nixpkgs";
+
     nixpkgs-update-github-releases.flake = false;
+    nixpkgs-update-github-releases.url = "github:ryantm/nixpkgs-update-github-releases";
 
     nur-update.url = "github:nix-community/nur-update";
     nur-update.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Reduce the number of instances of nixpkgs in the flake.lock, and use the version that's tested with SrvOS.