### PR TITLE
flake: split up per host

### DIFF
--- a/build01/configuration.nix
+++ b/build01/configuration.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ inputs, ... }:
 # Boot recovery:
 # Activate 64-bit Rescue system in https://robot.your-server.de/server
 # ssh root@build01.nix-community.org "mount /dev/md[0-9]* /mnt && /mnt/kexec_bundle"
@@ -11,6 +11,7 @@
 # nixos-enter
 {
   imports = [
+    inputs.srvos.nixosModules.hardware-hetzner-online-amd
     ../roles/common.nix
     ../roles/raid.nix
     ../roles/zfs.nix

--- a/build01/default.nix
+++ b/build01/default.nix
@@ -1,0 +1,7 @@
+{ self, ... }:
+{
+  flake.nixosConfigurations.build01 = self.lib.nixosSystem {
+    system = "x86_64-linux";
+    modules = [ ./configuration.nix ];
+  };
+}

--- a/build02/configuration.nix
+++ b/build02/configuration.nix
@@ -1,7 +1,9 @@
-{ ... }:
+{ inputs, ... }:
 
 {
   imports = [
+    inputs.srvos.nixosModules.mixins-nginx
+    inputs.srvos.nixosModules.hardware-hetzner-online-amd
     ./nixpkgs-update.nix
     ./nixpkgs-update-backup.nix
     ../roles/common.nix

--- a/build02/default.nix
+++ b/build02/default.nix
@@ -1,0 +1,8 @@
+{ self, ... }:
+{
+  flake.nixosConfigurations.build02 = self.lib.nixosSystem {
+    system = "x86_64-linux";
+    modules = [ ./configuration.nix ];
+  };
+}
+

--- a/build03/configuration.nix
+++ b/build03/configuration.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ inputs, ... }:
 {
   # Boot recovery:
   # Activate 64-bit Rescue system in https://robot.your-server.de/server
@@ -10,6 +10,8 @@
   # $ zpool import -f zroot && mount -t zfs zroot/root/nixos /mnt && mount -t zfs zroot/root/home /mnt/home && mount /dev/md[0-9]* /mnt/boot
   # $ nixos-enter
   imports = [
+    inputs.srvos.nixosModules.mixins-nginx
+    inputs.srvos.nixosModules.hardware-hetzner-online-amd
     ../roles/common.nix
     ../roles/hercules-ci
     ../roles/watch-store.nix

--- a/build03/default.nix
+++ b/build03/default.nix
@@ -1,0 +1,7 @@
+{ self, ... }:
+{
+  flake.nixosConfiguration.build03 = self.lib.nixosSystem {
+    system = "x86_64-linux";
+    modules = [ ./configuration.nix ];
+  };
+}

--- a/build04/configuration.nix
+++ b/build04/configuration.nix
@@ -1,5 +1,7 @@
+{ inputs, ... }:
 {
   imports = [
+    inputs.disko.nixosModules.disko
     ./hardware-configuration.nix
     ../roles/common.nix
     ../roles/hercules-ci

--- a/build04/default.nix
+++ b/build04/default.nix
@@ -1,0 +1,7 @@
+{ self, ... }:
+{
+  flake.nixosConfigurations.build04 = self.lib.nixosSystem {
+    system = "aarch64-linux";
+    modules = [ ./configuration.nix ];
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -42,107 +42,64 @@
   };
 
   outputs = inputs @ { flake-parts, self, ... }:
-    flake-parts.lib.mkFlake
-      { inherit inputs; }
-      {
-        systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
 
-        herculesCI = { lib, ... }: {
-          ciSystems = [ "x86_64-linux" "aarch64-linux" ];
+      herculesCI = { lib, ... }: {
+        ciSystems = [ "x86_64-linux" "aarch64-linux" ];
 
-          onPush.default.outputs = {
-            checks = lib.mkForce self.outputs.checks.x86_64-linux;
-          };
+        onPush.default.outputs = {
+          checks = lib.mkForce self.outputs.checks.x86_64-linux;
         };
-
-        hercules-ci.flake-update = {
-          enable = true;
-          createPullRequest = true;
-          autoMergeMethod = "rebase";
-          when = {
-            hour = [ 2 ];
-            dayOfWeek = [ "Mon" "Thu" ];
-          };
-        };
-
-        imports = [
-          inputs.hercules-ci-effects.flakeModule
-          inputs.treefmt-nix.flakeModule
-          ./effect.nix
-          ./shell.nix
-        ];
-
-        hercules-ci.github-pages.branch = "master";
-
-        perSystem = { config, pkgs, ... }: {
-          treefmt.imports = [ ./treefmt.nix ];
-
-          packages.pages = pkgs.runCommand "pages"
-            {
-              buildInputs = [ pkgs.python3.pkgs.mkdocs-material ];
-            } ''
-            cp -r ${pkgs.lib.cleanSource ./.}/* .
-            mkdocs build --strict --site-dir $out
-          '';
-
-          hercules-ci.github-pages.settings.contents = config.packages.pages;
-        };
-
-        flake.nixosConfigurations =
-          let
-            inherit (inputs.nixpkgs.lib) nixosSystem;
-            common = [
-              { _module.args.inputs = inputs; }
-              { srvos.flake = inputs.self; }
-              inputs.sops-nix.nixosModules.sops
-              inputs.srvos.nixosModules.server
-
-              inputs.srvos.nixosModules.mixins-telegraf
-              { networking.firewall.allowedTCPPorts = [ 9273 ]; }
-            ];
-          in
-          {
-            build01 = nixosSystem {
-              system = "x86_64-linux";
-              modules =
-                common
-                ++ [
-                  ./build01/configuration.nix
-                  inputs.srvos.nixosModules.hardware-hetzner-online-amd
-                ];
-            };
-
-            build02 = nixosSystem {
-              system = "x86_64-linux";
-              modules =
-                common
-                ++ [
-                  ./build02/configuration.nix
-                  inputs.srvos.nixosModules.mixins-nginx
-                  inputs.srvos.nixosModules.hardware-hetzner-online-amd
-                ];
-            };
-
-            build03 = nixosSystem {
-              system = "x86_64-linux";
-              modules =
-                common
-                ++ [
-                  ./build03/configuration.nix
-                  inputs.srvos.nixosModules.mixins-nginx
-                  inputs.srvos.nixosModules.hardware-hetzner-online-amd
-                ];
-            };
-
-            build04 = nixosSystem {
-              system = "aarch64-linux";
-              modules =
-                common
-                ++ [
-                  ./build04/configuration.nix
-                  inputs.disko.nixosModules.disko
-                ];
-            };
-          };
       };
+
+      hercules-ci.flake-update = {
+        enable = true;
+        createPullRequest = true;
+        autoMergeMethod = "rebase";
+        when = {
+          hour = [ 2 ];
+          dayOfWeek = [ "Mon" "Thu" ];
+        };
+      };
+
+      hercules-ci.github-pages.branch = "master";
+
+      imports = [
+        inputs.hercules-ci-effects.flakeModule
+        inputs.treefmt-nix.flakeModule
+        ./effect.nix
+        ./shell.nix
+        ./build01
+        ./build02
+        ./build03
+        ./build04
+      ];
+
+      perSystem = { config, pkgs, ... }: {
+        treefmt.imports = [ ./treefmt.nix ];
+
+        packages.pages = pkgs.runCommand "pages"
+          {
+            buildInputs = [ pkgs.python3.pkgs.mkdocs-material ];
+          } ''
+          cp -r ${pkgs.lib.cleanSource ./.}/* .
+          mkdocs build --strict --site-dir $out
+        '';
+
+        hercules-ci.github-pages.settings.contents = config.packages.pages;
+      };
+
+      flake.lib.nixosSystem = args:
+        inputs.nixpkgs.lib.nixosSystem ({ specialArgs = { inherit inputs; }; } // args);
+
+      flake.nixosModules = {
+        common = ./roles/common.nix;
+      };
+    };
 }

--- a/roles/common.nix
+++ b/roles/common.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ inputs, pkgs, ... }:
 {
   imports = [
     ./auto-upgrade.nix
@@ -6,7 +6,14 @@
     ./security.nix
     ./sops-nix.nix
     ./users.nix
+    inputs.sops-nix.nixosModules.sops
+    inputs.srvos.nixosModules.mixins-telegraf
+    inputs.srvos.nixosModules.server
   ];
+
+  networking.firewall.allowedTCPPorts = [ 9273 ];
+
+  srvos.flake = inputs.self;
 
   zramSwap.enable = true;
 


### PR DESCRIPTION
Inject the inputs in specialArgs so they can be used in the modules directly. This allows us to split up the top-level flake as well.