### PR TITLE
flake: build packages on x86_64-linux only

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
 
           onPush.default.outputs = {
             checks = lib.mkForce self.outputs.checks.x86_64-linux;
+            packages = lib.mkForce self.outputs.packages.x86_64-linux;
           };
         };
 


### PR DESCRIPTION
This only needs to be built by CI on x86_64-linux for deploying to github pages.