### PR TITLE
.github/settings.yml: make dpulls a required check

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -146,6 +146,7 @@ branches:
         contexts:
           - ci/hercules/evaluation
           - ci/hercules/onPush/default
+          - dpulls
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: true
       # Disabled for bors to work


### PR DESCRIPTION
I'd like to enable https://github.com/marketplace/dpulls for this repo and make it a required check, it is useful for stacking PRs.

It's been used in https://github.com/NixOS/nix for while now.