### PR TITLE
switch back to post-build-hook

### DIFF
--- a/build03/configuration.nix
+++ b/build03/configuration.nix
@@ -14,7 +14,6 @@
     inputs.srvos.nixosModules.hardware-hetzner-online-amd
     ../roles/common.nix
     ../roles/hercules-ci
-    ../roles/watch-store.nix
     ../roles/raid.nix
     ../roles/zfs.nix
     ../roles/remote-builder/aarch64-build04.nix


### PR DESCRIPTION
Seems watch-store in cachix 1.5 has problems. Cachix can push paths so using post-build-hook and nixpkgs-update on build02 works.

```
May 26 05:55:34 build03 systemd[1]: cachix-watch-store-agent.service: Failed with result 'exit-code'.
May 26 05:55:34 build03 systemd[1]: cachix-watch-store-agent.service: Consumed 152ms CPU time, received 4.8K IP traffic, sent 1.6K IP traffic.
May 26 05:55:35 build03 systemd[1]: cachix-watch-store-agent.service: Scheduled restart job, restart counter is at 1045.
May 26 05:55:35 build03 systemd[1]: Stopped Cachix watch store Agent.
May 26 05:55:35 build03 systemd[1]: cachix-watch-store-agent.service: Consumed 152ms CPU time, received 4.8K IP traffic, sent 1.6K IP traffic.
May 26 05:55:35 build03 systemd[1]: Started Cachix watch store Agent.
May 26 05:55:36 build03 cachix-watch-store-agent-start[409890]: Watching /nix/store for new store paths ...
May 26 05:55:36 build03 cachix-watch-store-agent-start[409890]: cachix: CppStdException e "\ESC[31;1merror:\ESC[0m path '\ESC[35;1m/nix/store/amr7kh9m5na4dvc8x56259kwr04b5d8w-emacs-wordreference-20230502.1531\ESC[0m' is not valid"(Just "nix::InvalidPath")
May 26 05:55:36 build03 systemd[1]: cachix-watch-store-agent.service: Main process exited, code=exited, status=1/FAILURE
May 26 05:55:36 build03 systemd[1]: cachix-watch-store-agent.service: Failed with result 'exit-code'.
```