### PR TITLE
hosts/darwin02: add telegraf

### DIFF
--- a/hosts/darwin02/configuration.nix
+++ b/hosts/darwin02/configuration.nix
@@ -11,7 +11,7 @@ in
     package = inputs.hcia.legacyPackages.${pkgs.system}.hercules-ci-agent;
   };
 
-  imports = [ ./builder.nix ];
+  imports = [ ./builder.nix ./telegraf.nix ];
 
   services.nix-daemon.enable = true;
 

--- a/hosts/darwin02/telegraf.nix
+++ b/hosts/darwin02/telegraf.nix
@@ -1,6 +1,22 @@
+{ pkgs, ... }:
 {
   services.telegraf = {
     enable = true;
+    # can switch back to nixpkgs after > 1.26.3
+    package = pkgs.buildGoModule rec {
+      pname = "telegraf";
+      version = "1.26.3";
+      subPackages = [ "cmd/telegraf" ];
+      src = pkgs.fetchFromGitHub {
+        owner = "influxdata";
+        repo = "telegraf";
+        rev = "ebe346103ebfd96b63cdbd2f3f36b2258746c160";
+        hash = "sha256-j6VWbF6B7+TQlLNdQMwN7r4kOUGQi5c/PigNZhJA2Zk=";
+      };
+      vendorHash = "sha256-4WmXEa42zyeRGcdXe4REILYNMZZ83FVzDDaKFMnx37Y=";
+      proxyVendor = true;
+      ldflags = [ "-s" "-w" "-X=github.com/influxdata/telegraf/internal.Commit=${src.rev}" "-X=github.com/influxdata/telegraf/internal.Version=${version}" ];
+    };
     extraConfig = {
       agent.interval = "60s";
       inputs = {

--- a/hosts/darwin02/telegraf.nix
+++ b/hosts/darwin02/telegraf.nix
@@ -1,0 +1,22 @@
+{
+  services.telegraf = {
+    enable = true;
+    extraConfig = {
+      agent.interval = "60s";
+      inputs = {
+        prometheus.metric_version = 2;
+        system = { };
+        mem = { };
+        disk.tagdrop = {
+          fstype = [ "tmpfs" "ramfs" "devtmpfs" "devfs" "iso9660" "overlay" "aufs" "squashfs" ];
+          device = [ "rpc_pipefs" "lxcfs" "nsfs" "borgfs" ];
+        };
+        diskio = { };
+      };
+      outputs.prometheus_client = {
+        listen = ":9273";
+        metric_version = 2;
+      };
+    };
+  };
+}


### PR DESCRIPTION
This is a basic version of the srvos telegraf module, dropped everything that requires sudo or is linux specific.

~~Also needs to be added in https://github.com/Mic92/dotfiles/blob/main/nixos/eva/modules/prometheus/default.nix#L118.~~ https://github.com/Mic92/dotfiles/pull/681