### PR TITLE
switch to mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,17 @@
+pull_request_rules:
+  - name: automatic merge on CI success
+    conditions:
+      - base=master
+      - check-success=ci/hercules/evaluation
+      - check-success=ci/hercules/onPush/default
+      - or:
+          - and:
+              - author=github-actions[bot]
+              - label=automerge
+          - and:
+              - author=hercules-ci[bot]
+    actions:
+      merge:
+        method: rebase
+        allow_merging_configuration_change: true
+      delete_head_branch: {}

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -152,6 +152,6 @@ branches:
       required_linear_history: false
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
       restrictions:
-        apps: ["hercules-ci"]
-        users: ["nix-infra-bot"]
+        apps: ["mergify"]
+        users: []
         teams: []

--- a/.github/workflows/flake-updates-nixpkgs-update.yml
+++ b/.github/workflows/flake-updates-nixpkgs-update.yml
@@ -13,12 +13,8 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Update flake.lock
-        id: update
         uses: DeterminateSystems/update-flake-lock@v19
         with:
-          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
           inputs: nixpkgs-update
-      - name: Enable Automerge
-        run: gh pr merge --rebase --auto "${{ steps.update.outputs.pull-request-number }}"
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          pr-labels: |
+            automerge

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,6 @@
         hercules-ci.flake-update = {
           enable = true;
           createPullRequest = true;
-          autoMergeMethod = "rebase";
           when = {
             hour = [ 2 ];
             dayOfWeek = [ "Mon" "Thu" ];


### PR DESCRIPTION
this lets us consolidate automerges and remove GH_TOKEN_FOR_UPDATES

not using mergify merge queue function as we'd need to modify the effects.