### PR TITLE
Fix xfsprogs missing in cloud-init

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -213,11 +213,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689450984,
-        "narHash": "sha256-MKxRStH/g/qFO7/qDtZlmnFky+Zf542yJZx9EmEQnek=",
+        "lastModified": 1689592530,
+        "narHash": "sha256-JzzyIZPI5Nsn56phEQoOvF69cI1QYoPo/pSorhAtSo4=",
         "owner": "numtide",
         "repo": "srvos",
-        "rev": "0b88224a7a55640402c0ba8427d17ce55fd0a421",
+        "rev": "0fc20928d185a38d0081a2a22278d4e5cd2a2035",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
https://github.com/numtide/srvos/pull/199

```
[mic92@web01:~]$ sudo systemctl cat cloud-init | grep --color xfs
Environment="PATH=/nix/store/z3raph8hi3z246cvian7kcx9yynwwnz5-cloud-init-23.2.1/bin:/nix/store/x7kkkxxl84xjynyqw8gv89nd17myril2-iproute2-6.3.0/bin:/nix/store/ymq5hsa5lrsg5an8w2fs09na0djbrk38-net-tools-2.10/bin:/nix/store/8x654pvf2g43sqkc0y2p4l77rscrsnnd-openssh-9.3p1/bin:/nix/store/zhd1016mmay8ci08c5s99xd6wb1b0r0q-shadow-4.13/bin:/nix/store/gpwv7ynjx4h3k1viw96yfwxsid0ml9wc-util-linux-2.39-bin/bin:/nix/store/zb807hx0sxl5lf8kn9mhhfakxcjls5lb-busybox-1.36.1/bin:/nix/store/d3166x4xa84wv69vm5icqj970gf1yjj4-xfsprogs-6.3.0-bin/bin:/nix/store/c2bq8xsayc90s33fd5xbm1vh5lrmwcfq-coreutils-9.3/bin:/nix/store/dq11g3lzkl5bxrjy9y6x1pjxkxx6z91f-findutils-4.9.0/bin:/nix/store/yw3g789y5fpmxbzgkhs4nv7xdnyklsjd-gnugrep-3.11/bin:/nix/store/n31qkcw7f4jkkl0crczd6hiyy8sdjaz5-gnused-4.9/bin:/nix/store/3dvqpndk3sqxwjqlcbm39a0k20skhs8c-systemd-253.5/bin:/nix/store/z3raph8hi3z246cvian7kcx9yynwwnz5-cloud-init-23.2.1/sbin:/nix/store/x7kkkxxl84xjynyqw8gv89nd17myril2-iproute2-6.3.0/sbin:/nix/store/ymq5hsa5lrsg5an8w2fs09na0djbrk38-net-tools-2.10/sbin:/nix/store/8x654pvf2g43sqkc0y2p4l77rscrsnnd-openssh-9.3p1/sbin:/nix/store/zhd1016mmay8ci08c5s99xd6wb1b0r0q-shadow-4.13/sbin:/nix/store/gpwv7ynjx4h3k1viw96yfwxsid0ml9wc-util-linux-2.39-bin/sbin:/nix/store/zb807hx0sxl5lf8kn9mhhfakxcjls5lb-busybox-1.36.1/sbin:/nix/store/d3166x4xa84wv69vm5icqj970gf1yjj4-xfsprogs-6.3.0-bin/sbin:/nix/store/c2bq8xsayc90s33fd5xbm1vh5lrmwcfq-coreutils-9.3/sbin:/nix/store/dq11g3lzkl5bxrjy9y6x1pjxkxx6z91f-findutils-4.9.0/sbin:/nix/store/yw3g789y5fpmxbzgkhs4nv7xdnyklsjd-gnugrep-3.11/sbin:/nix/store/n31qkcw7f4jkkl0crczd6hiyy8sdjaz5-gnused-4.9/sbin:/nix/store/3dvqpndk3sqxwjqlcbm39a0k20skhs8c-systemd-253.5/sbin"
```
