### PR TITLE
builder/users: add lily

### DIFF
--- a/modules/nixos/community-builder/keys/lily
+++ b/modules/nixos/community-builder/keys/lily
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGKYH3ivyXgnhXL6xgZxZifRclw+2xsxWNdNe1ghjw7A lily@bina

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -47,6 +47,11 @@ let
       keys = ./keys/lewo;
     };
 
+    lily = {
+      trusted = true;
+      keys = ./keys/lily;
+    };
+
     raitobezarius = {
       trusted = true;
       keys = ./keys/raitobezarius;


### PR DESCRIPTION
- [x] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [x] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [x] I know when I can't trust the builder, as explained in the README

I'm already in the aarch64 and darwin community builders, but being able to do x86_64-linux builds on a remote builder to review and create nixpkgs PRs will probably be a good thing for my laptop (especially cross testing and such...)

Let me know if I need to provide more info to use the community builder, thank you!