### PR TITLE
modules/darwin/common: add flake-inputs

### DIFF
--- a/modules/darwin/common/default.nix
+++ b/modules/darwin/common/default.nix
@@ -4,6 +4,7 @@ let
 in
 {
   imports = [
+    ./flake-inputs.nix
     ./telegraf.nix
   ];
 

--- a/modules/darwin/common/flake-inputs.nix
+++ b/modules/darwin/common/flake-inputs.nix
@@ -1,0 +1,27 @@
+{ inputs, lib, pkgs, ... }:
+
+{
+  services.telegraf.extraConfig.inputs.file =
+    let
+      inputsWithDate = lib.filterAttrs (_: input: input ? lastModified) inputs.self;
+      flakeAttrs = input: (lib.mapAttrsToList (n: v: ''${n}="${v}"'')
+        (lib.filterAttrs (_: v: (builtins.typeOf v) == "string") input));
+      lastModified = name: input: ''
+        flake_input_last_modified{input="${name}",${lib.concatStringsSep "," (flakeAttrs input)}} ${toString input.lastModified}'';
+
+      # avoid adding store path references on flakes which me not need at runtime.
+      promText = builtins.unsafeDiscardStringContext ''
+        # HELP flake_registry_last_modified Last modification date of flake input in unixtime
+        # TYPE flake_input_last_modified gauge
+        ${lib.concatStringsSep "\n" (lib.mapAttrsToList lastModified inputsWithDate)}
+      '';
+    in
+    [
+      {
+        data_format = "prometheus";
+        files = [
+          (pkgs.writeText "flake-inputs.prom" promText)
+        ];
+      }
+    ];
+}


### PR DESCRIPTION
This is useful as we're currently deploying the darwin hosts manually.