### PR TITLE
docs: fix OpenCollective banner height

### DIFF
--- a/docs/open-collective.md
+++ b/docs/open-collective.md
@@ -1,1 +1,6 @@
+<style>
+div.opencollective-banner > iframe {
+    height: 700px;
+}
+</style>
 <script src="https://opencollective.com/nix-community/banner.js"></script>


### PR DESCRIPTION
I couldn't find a way to set the height in their docs, so hack it.