### PR TITLE
Revert "build01: cachix deploy"

### DIFF
--- a/dev/effect.nix
+++ b/dev/effect.nix
@@ -4,17 +4,11 @@
     withSystem "x86_64-linux" ({ hci-effects, pkgs, self', ... }:
       let
         inherit (config.repo) ref;
-        inherit (hci-effects) mkEffect runCachixDeploy runIf;
+        inherit (hci-effects) mkEffect runIf;
         inherit (pkgs.lib) hasPrefix;
       in
       {
         onPush.default.outputs.effects = {
-          cachix-deploy = runIf (hasPrefix "refs/heads/gh-readonly-queue/master/" ref)
-            (runCachixDeploy {
-              deploy.agents = {
-                build01 = builtins.unsafeDiscardStringContext self.nixosConfigurations.build01.config.system.build.toplevel;
-              };
-            });
           terraform-deploy = runIf (hasPrefix "refs/heads/gh-readonly-queue/master/" ref)
             (mkEffect {
               name = "terraform-deploy";

--- a/hosts/build01/configuration.nix
+++ b/hosts/build01/configuration.nix
@@ -16,7 +16,6 @@
     inputs.self.nixosModules.raid
     inputs.self.nixosModules.zfs
     inputs.self.nixosModules.community-builder
-    inputs.self.nixosModules.cachix-deploy
   ];
 
   # Emulate riscv64 until we have proper builders


### PR DESCRIPTION
https://app.cachix.org/organization/nix-community/deploy/workspace/community-infra/agent/build01

Added this in https://github.com/nix-community/infra/pull/688 just to try it out, can switch back to the standard update method now.

I'll probably switch to using `cachix deploy` like this for our darwin machines once the CI issues are resolved.

Needs to be deployed manually to `build01` after this PR is merged.