### PR TITLE
modules/darwin/builder: various

### DIFF
--- a/modules/darwin/builder.nix
+++ b/modules/darwin/builder.nix
@@ -1,12 +1,5 @@
 {
-  users.knownGroups = [ "nix" ];
   users.knownUsers = [ "nix" ];
-
-  users.groups.nix = {
-    name = "nix";
-    gid = 8765;
-    description = "Group for remote build clients";
-  };
 
   users.users.nix = {
     name = "nix";
@@ -14,12 +7,16 @@
     home = "/Users/nix";
     createHome = true;
     shell = "/bin/zsh";
-    description = "User for remote build clients";
     # if user is removed the keys need to be removed manually from /etc/ssh/authorized_keys.d
     openssh.authorizedKeys.keys = [
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEmdo1x1QkRepZf7nSe+OdEWX+wOjkBLF70vX9F+xf68 builder"
     ];
   };
+
+  # add build user to group for ssh access
+  system.activationScripts.postActivation.text = ''
+    dseditgroup -o edit -a "nix" -t user com.apple.access_ssh
+  '';
 
   nix.settings.trusted-users = [ "nix" ];
 }


### PR DESCRIPTION
- drop unnecessary description and group

- use postActivation to give build user ssh access