### PR TITLE
modules/darwin/common: refactor authorizedKeys

### DIFF
--- a/hosts/darwin02/configuration.nix
+++ b/hosts/darwin02/configuration.nix
@@ -16,13 +16,4 @@
   networking.hostName = "darwin02";
 
   system.stateVersion = 4;
-
-  # TODO: refactor this to share /users with nixos
-  # if user is removed the keys need to be removed manually from /etc/ssh/authorized_keys.d
-  users.users.hetzner.openssh.authorizedKeys.keys = [
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOG/9rsFqC2tg+W5YZxthW5xhUJEfZ8ShqkRtVe+A6+u" # hercules-ssh-deploy
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKbBp2dH2X3dcU1zh+xW3ZsdYROKpJd3n13ssOP092qE" # mic92
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOuiDoBOxgyer8vGcfAIbE6TC4n4jo8lhG9l01iJ0bZz" # zimbatm
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFbCYwWByGE46XHH4Q0vZgQ5sOUgbH50M8KO2xhBC4m/" # zowoq
-  ];
 }

--- a/hosts/darwin03/configuration.nix
+++ b/hosts/darwin03/configuration.nix
@@ -16,13 +16,4 @@
   networking.hostName = "darwin03";
 
   system.stateVersion = 4;
-
-  # TODO: refactor this to share /users with nixos
-  # if user is removed the keys need to be removed manually from /etc/ssh/authorized_keys.d
-  users.users.hetzner.openssh.authorizedKeys.keys = [
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOG/9rsFqC2tg+W5YZxthW5xhUJEfZ8ShqkRtVe+A6+u" # hercules-ssh-deploy
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKbBp2dH2X3dcU1zh+xW3ZsdYROKpJd3n13ssOP092qE" # mic92
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOuiDoBOxgyer8vGcfAIbE6TC4n4jo8lhG9l01iJ0bZz" # zimbatm
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFbCYwWByGE46XHH4Q0vZgQ5sOUgbH50M8KO2xhBC4m/" # zowoq
-  ];
 }

--- a/modules/darwin/common/default.nix
+++ b/modules/darwin/common/default.nix
@@ -7,6 +7,17 @@
     ../../shared/nix-daemon.nix
   ];
 
+  # TODO: refactor this to share /users with nixos
+  # if user is removed the keys need to be removed manually from /etc/ssh/authorized_keys.d
+  users.users = {
+    hetzner.openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOG/9rsFqC2tg+W5YZxthW5xhUJEfZ8ShqkRtVe+A6+u" # hercules-ssh-deploy
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKbBp2dH2X3dcU1zh+xW3ZsdYROKpJd3n13ssOP092qE" # mic92
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOuiDoBOxgyer8vGcfAIbE6TC4n4jo8lhG9l01iJ0bZz" # zimbatm
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFbCYwWByGE46XHH4Q0vZgQ5sOUgbH50M8KO2xhBC4m/" # zowoq
+    ];
+  };
+
   # use the same version as srvos
   # https://github.com/numtide/srvos/blob/main/nixos/common/nix.nix#L4
   nix.package = pkgs.nixVersions.nix_2_16;


### PR DESCRIPTION
As we only have hetzner machines at the moment we can share this user/keys between hosts but we'll need to change it if we add a non-hetzner machine.