### PR TITLE
docs/sponsors.md: fix link

### DIFF
--- a/docs/sponsors.md
+++ b/docs/sponsors.md
@@ -1,7 +1,7 @@
 Thanks to all our sponsors.
 
 <!-- prettier-ignore-start -->
-|[<img src="https://raw.githubusercontent.com/cachix/docs.cachix.org/master/source/logo.png" width="200" alt="Cachix">](https://cachix.org)|[<img src="https://raw.githubusercontent.com/Gandi/.github/b1f21a402d9223c672476b41148429f538be5303/logos/black.svg" width="200" alt="Gandi">](https://www.gandi.net/)|[<img src="Logo_namespace_filled_lightbg.png" width="200" alt="Namespace">](https://cloud.namespace.so)|
+|[<img src="https://raw.githubusercontent.com/cachix/docs.cachix.org/master/source/logo.png" width="200" alt="Cachix">](https://cachix.org)|[<img src="https://raw.githubusercontent.com/Gandi/.github/b1f21a402d9223c672476b41148429f538be5303/logos/black.svg" width="200" alt="Gandi">](https://www.gandi.net/)|[<img src="../Logo_namespace_filled_lightbg.png" width="200" alt="Namespace">](https://cloud.namespace.so)|
 |:-:|:-:|:-:|
 |Cachix provides us with 1TB of free cache.|Gandi provides us with a free domain <br /> and a virtual private server.|Namespace provides us with faster GitHub runners, including ARM64.|
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
This will break the markdown but it'll fix the website.

https://nix-community.org/sponsors/

https://github.com/nix-community/infra/blob/109220365d467dd36998a1b21482336deef769cc/docs/sponsors.md