### PR TITLE
modules/nixos/monitoring/alert-rules: add matrix-alertmanager-receiver

### DIFF
--- a/modules/nixos/monitoring/alert-rules.nix
+++ b/modules/nixos/monitoring/alert-rules.nix
@@ -89,6 +89,11 @@ lib.mapAttrsToList
       description = "{{$labels.host}} failed to (re)start service {{$labels.name}}";
     };
 
+    matrix_alertmanager_receiver_not_running = {
+      condition = ''systemd_units_active_code{name="matrix-alertmanager-receiver.service", sub!="running"}'';
+      description = "{{$labels.host}} should have a running {{$labels.name}}";
+    };
+
     ram_using_95percent = {
       condition = "mem_buffered + mem_free + mem_cached < mem_total * 0.05";
       time = "1h";


### PR DESCRIPTION
Separate rule for the matrix service to improve visibility.