### PR TITLE
web01: add monitoring for lemmy

### DIFF
--- a/hosts/web01/lemmy.nix
+++ b/hosts/web01/lemmy.nix
@@ -7,8 +7,11 @@ in
   sops.secrets.pictrs-env = { };
   sops.secrets.lemmy-pictrsapikeyfile = { };
 
+  services.telegraf.extraConfig.inputs.prometheus.urls = [ "http://localhost:10002/metrics" ];
+
   services.lemmy = {
     enable = true;
+    server.package = pkgs.lemmy-server.overrideAttrs (_: { cargoBuildFeatures = [ "prometheus-metrics" ]; });
     nginx.enable = true;
     database.createLocally = true;
     pictrsApiKeyFile = config.sops.secrets.lemmy-pictrsapikeyfile.path;


### PR DESCRIPTION
Upstream may change this to enabled by default so probably not worth the effort of adding it in nixpkgs.

~~I'll leave this until we have the dashboard running.~~

Don't really need this at the moment.