### PR TITLE
community-builder packages: Add mosh

### DIFF
--- a/modules/nixos/community-builder/packages.nix
+++ b/modules/nixos/community-builder/packages.nix
@@ -18,4 +18,12 @@
     pkgs.termite.terminfo
     pkgs.wezterm.terminfo
   ];
+
+  networking.firewall.allowedUDPPortRanges = [
+    # Reserved for mosh
+    {
+      from = 60000;
+      to = 61000;
+    }
+  ];
 }

--- a/modules/nixos/community-builder/packages.nix
+++ b/modules/nixos/community-builder/packages.nix
@@ -4,6 +4,7 @@
   environment.systemPackages = [
     pkgs.fd
     pkgs.git
+    pkgs.mosh
     pkgs.nano
     pkgs.nix-output-monitor
     pkgs.nix-tree


### PR DESCRIPTION
I would like to propose to add `mosh` ([mosh.org](https://mosh.org/)) to the community builder.

I like to keep my ssh sessions via suspends, and this helps.