### PR TITLE
build02/nixpkgs-update: tee worker stdout and stderr to log files

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -13,6 +13,7 @@ let
     curl
     getent # used by hub
     cachix
+    apacheHttpd # for rotatelogs, used by worker script
   ];
 
   nixpkgs-update-github-releases' = "${inputs.nixpkgs-update-github-releases}/main.py";
@@ -47,6 +48,9 @@ let
     };
 
     script = ''
+      exec  > >(rotatelogs -eD "$LOGS_DIRECTORY"'/~workers/%Y-%m-%d-${name}.stdout.log' 86400)
+      exec 2> >(rotatelogs -eD "$LOGS_DIRECTORY"'/~workers/%Y-%m-%d-${name}.stderr.log' 86400 >&2)
+
       pipe=/var/lib/nixpkgs-update/fifo
 
       if [[ ! -p $pipe ]]; then


### PR DESCRIPTION
I'm fishing for information about what happens to nixpkgs-update when it doesn't even start to update a package (so there is no log in the directory corresponding to the package), like if it's asked to do an update on `ppyytthhoonnPaPackckaaggeess..fboaor` or something.

This will make a new log folder named `~workers` in https://r.ryantm.com/log/; name chosen to appear at the end of the list and not conflict with real packages.

I tried to make this minimally disruptive to any existing monitoring infrastructure. In particular, stdout and stderr should still be echoed to the systemd journal; with the `-e` flag, rotatelogs will write input to files and also echo it to stdout.