### PR TITLE
modules/nixos/monitoring: disable alertmanager clustering

### DIFF
--- a/modules/nixos/monitoring/prometheus.nix
+++ b/modules/nixos/monitoring/prometheus.nix
@@ -59,6 +59,7 @@
     enable = true;
     webExternalUrl = "https://alertmanager.nix-community.org";
     listenAddress = "[::1]";
+    extraFlags = [ "--cluster.listen-address=''" ];
     configuration = {
       route = {
         receiver = "default";


### PR DESCRIPTION
I thought this was disabled by default in nixpkgs but apparently not.