### PR TITLE
flake: unpin nixpkgs-update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -106,17 +106,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1681047420,
-        "narHash": "sha256-s+jolCAlBLVh+3e/QkMlbSENvlZuOJ3FAwsOvLmsRKY=",
+        "lastModified": 1694697080,
+        "narHash": "sha256-23mD1WWFVyS8xanVRydgDXMJazsjC4yzzY0fzlPVUso=",
         "owner": "ryantm",
         "repo": "nixpkgs-update",
-        "rev": "074e47e7a813312c758f8f121d82041d312b9413",
+        "rev": "8fedf8f6f29280578e335bf4483c9f88d4bcdbaa",
         "type": "github"
       },
       "original": {
         "owner": "ryantm",
         "repo": "nixpkgs-update",
-        "rev": "074e47e7a813312c758f8f121d82041d312b9413",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
     # actually not used when using the modules but than nothing ever will try to fetch this nixpkgs variant
     srvos.inputs.nixpkgs.follows = "nixpkgs";
 
-    nixpkgs-update.url = "github:ryantm/nixpkgs-update/074e47e7a813312c758f8f121d82041d312b9413";
+    nixpkgs-update.url = "github:ryantm/nixpkgs-update";
     nixpkgs-update.inputs.mmdoc.follows = "";
     nixpkgs-update-github-releases.url = "github:ryantm/nixpkgs-update-github-releases";
     nixpkgs-update-github-releases.flake = false;


### PR DESCRIPTION
Blocked on https://github.com/ryantm/nixpkgs-update/pull/360, https://github.com/ryantm/nixpkgs-update/pull/361

There isn't any urgency here, we can wait for the PRs to be merged upstream.