### PR TITLE
move alertmanager, prometheus under monitoring.nix-community.org

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,2 +1,2 @@
-- [alertmanager.nix-community.org](https://alertmanager.nix-community.org)
-- [prometheus.nix-community.org](https://prometheus.nix-community.org)
+- [monitoring.nix-community.org/alertmanager](https://monitoring.nix-community.org/alertmanager)
+- [monitoring.nix-community.org/prometheus](https://monitoring.nix-community.org/prometheus)

--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -4,4 +4,12 @@
     ./prometheus.nix
     ./telegraf.nix
   ];
+
+  services.nginx.virtualHosts."monitoring.nix-community.org" = {
+    enableACME = true;
+    forceSSL = true;
+    locations."/".return = "302 https://nix-community.org/monitoring";
+    locations."/alertmanager/".proxyPass = "http://localhost:9093";
+    locations."/prometheus/".proxyPass = "http://localhost:9090";
+  };
 }

--- a/modules/nixos/monitoring/prometheus.nix
+++ b/modules/nixos/monitoring/prometheus.nix
@@ -15,7 +15,7 @@
         ];
       }))
     ];
-    webExternalUrl = "https://prometheus.nix-community.org";
+    webExternalUrl = "https://monitoring.nix-community.org/prometheus/";
     scrapeConfigs = [
       {
         job_name = "telegraf";
@@ -49,15 +49,9 @@
     "http://localhost:9093/metrics" # alertmanager
   ];
 
-  services.nginx.virtualHosts."prometheus.nix-community.org" = {
-    enableACME = true;
-    forceSSL = true;
-    locations."/".proxyPass = "http://localhost:9090";
-  };
-
   services.prometheus.alertmanager = {
     enable = true;
-    webExternalUrl = "https://alertmanager.nix-community.org";
+    webExternalUrl = "https://monitoring.nix-community.org/alertmanager/";
     listenAddress = "[::1]";
     extraFlags = [ "--cluster.listen-address=''" ];
     configuration = {
@@ -88,11 +82,5 @@
         }
       ];
     };
-  };
-
-  services.nginx.virtualHosts."alertmanager.nix-community.org" = {
-    enableACME = true;
-    forceSSL = true;
-    locations."/".proxyPass = "http://localhost:9093";
   };
 }

--- a/terraform/cloudflare_nix-community_org.tf
+++ b/terraform/cloudflare_nix-community_org.tf
@@ -162,23 +162,9 @@ resource "cloudflare_record" "nix-community-org-nur-update-CNAME" {
   type    = "CNAME"
 }
 
-resource "cloudflare_record" "nix-community-org-alertmanager-CNAME" {
+resource "cloudflare_record" "nix-community-org-monitoring-CNAME" {
   zone_id = local.nix_community_zone_id
-  name    = "alertmanager"
-  value   = "web02.nix-community.org"
-  type    = "CNAME"
-}
-
-resource "cloudflare_record" "nix-community-org-grafana-CNAME" {
-  zone_id = local.nix_community_zone_id
-  name    = "grafana"
-  value   = "web02.nix-community.org"
-  type    = "CNAME"
-}
-
-resource "cloudflare_record" "nix-community-org-prometheus-CNAME" {
-  zone_id = local.nix_community_zone_id
-  name    = "prometheus"
+  name    = "monitoring"
   value   = "web02.nix-community.org"
   type    = "CNAME"
 }


### PR DESCRIPTION
This seems to be a bit neater than having multiple subdomains, etc.

Mostly copied from [nixos-org-configurations](https://github.com/NixOS/nixos-org-configurations/blob/3ca70f40caf1d5099b9382e2aa15ba863b8aad67/delft/eris.nix#L80).