### PR TITLE
web01: add `Upholds` to lemmy for pict-rs

### DIFF
--- a/hosts/web01/lemmy.nix
+++ b/hosts/web01/lemmy.nix
@@ -21,6 +21,8 @@ in
     };
   };
 
+  systemd.services.lemmy.unitConfig.Upholds = [ "pict-rs.service" ];
+
   services.nginx.virtualHosts.${domain} = {
     enableACME = true;
     forceSSL = true;


### PR DESCRIPTION
Seems like a bit of a hammer but it did work.

> https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Upholds=
> Configures dependencies similar to Wants=, but as long as this unit is up, all units listed in Upholds= are started whenever found to be inactive or failed, and no job is queued for them. While a Wants= dependency on another unit has a one-time effect when this units started, a Upholds= dependency on it has a continuous effect, constantly restarting the unit if necessary. This is an alternative to the Restart= setting of service units, to ensure they are kept running whatever happens. The restart happens without delay, and usual per-unit rate-limit applies.