### PR TITLE
Revert "move alertmanager, prometheus under monitoring.nix-community.org"

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,2 +1,2 @@
-- [monitoring.nix-community.org/alertmanager](https://monitoring.nix-community.org/alertmanager)
-- [monitoring.nix-community.org/prometheus](https://monitoring.nix-community.org/prometheus)
+- [alertmanager.nix-community.org](https://alertmanager.nix-community.org)
+- [prometheus.nix-community.org](https://prometheus.nix-community.org)

--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -4,12 +4,4 @@
     ./prometheus.nix
     ./telegraf.nix
   ];
-
-  services.nginx.virtualHosts."monitoring.nix-community.org" = {
-    enableACME = true;
-    forceSSL = true;
-    locations."/".return = "302 https://nix-community.org/monitoring";
-    locations."/alertmanager/".proxyPass = "http://localhost:9093";
-    locations."/prometheus/".proxyPass = "http://localhost:9090";
-  };
 }

--- a/modules/nixos/monitoring/prometheus.nix
+++ b/modules/nixos/monitoring/prometheus.nix
@@ -15,7 +15,7 @@
         ];
       }))
     ];
-    webExternalUrl = "https://monitoring.nix-community.org/prometheus/";
+    webExternalUrl = "https://prometheus.nix-community.org";
     scrapeConfigs = [
       {
         job_name = "telegraf";
@@ -49,9 +49,15 @@
     "http://localhost:9093/metrics" # alertmanager
   ];
 
+  services.nginx.virtualHosts."prometheus.nix-community.org" = {
+    enableACME = true;
+    forceSSL = true;
+    locations."/".proxyPass = "http://localhost:9090";
+  };
+
   services.prometheus.alertmanager = {
     enable = true;
-    webExternalUrl = "https://monitoring.nix-community.org/alertmanager/";
+    webExternalUrl = "https://alertmanager.nix-community.org";
     listenAddress = "[::1]";
     extraFlags = [ "--cluster.listen-address=''" ];
     configuration = {
@@ -82,5 +88,11 @@
         }
       ];
     };
+  };
+
+  services.nginx.virtualHosts."alertmanager.nix-community.org" = {
+    enableACME = true;
+    forceSSL = true;
+    locations."/".proxyPass = "http://localhost:9093";
   };
 }

--- a/terraform/cloudflare_nix-community_org.tf
+++ b/terraform/cloudflare_nix-community_org.tf
@@ -162,9 +162,23 @@ resource "cloudflare_record" "nix-community-org-nur-update-CNAME" {
   type    = "CNAME"
 }
 
-resource "cloudflare_record" "nix-community-org-monitoring-CNAME" {
+resource "cloudflare_record" "nix-community-org-alertmanager-CNAME" {
   zone_id = local.nix_community_zone_id
-  name    = "monitoring"
+  name    = "alertmanager"
+  value   = "web02.nix-community.org"
+  type    = "CNAME"
+}
+
+resource "cloudflare_record" "nix-community-org-grafana-CNAME" {
+  zone_id = local.nix_community_zone_id
+  name    = "grafana"
+  value   = "web02.nix-community.org"
+  type    = "CNAME"
+}
+
+resource "cloudflare_record" "nix-community-org-prometheus-CNAME" {
+  zone_id = local.nix_community_zone_id
+  name    = "prometheus"
   value   = "web02.nix-community.org"
   type    = "CNAME"
 }


### PR DESCRIPTION
Reverts nix-community/infra#801

Reverting this as alertmanager isn't receiving alerts from prometheus.