### PR TITLE
modules/shared/nix-daemon: fix `asGB`

### DIFF
--- a/modules/shared/nix-daemon.nix
+++ b/modules/shared/nix-daemon.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 
 let
-  asGB = size: toString (size * 1024 * 1024);
+  asGB = size: toString (size * 1024 * 1024 * 1024);
 in
 {
   nix = {


### PR DESCRIPTION
min-free, max-free and max-freed numbers are from https://github.com/NixOS/nixos-org-configurations/blob/master/macs/nix-darwin.nix, I think they're fine for all the hosts.