### PR TITLE
modules: add darwin/nixos builder, update min-free/max-free, increase open file limit

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -144,6 +144,7 @@
         flake.darwinModules = {
           common = ./modules/darwin/common;
 
+          builder = ./modules/darwin/builder.nix;
           hercules-ci = ./modules/darwin/hercules-ci;
           remote-builder = ./modules/darwin/remote-builder.nix;
         };
@@ -151,6 +152,7 @@
         flake.nixosModules = {
           common = ./modules/nixos/common;
 
+          builder = ./modules/nixos/builder.nix;
           cachix-deploy = ./modules/nixos/cachix-deploy;
           community-builder = ./modules/nixos/community-builder;
           github-org-backup = ./modules/nixos/github-org-backup.nix;

--- a/hosts/build01/configuration.nix
+++ b/hosts/build01/configuration.nix
@@ -13,6 +13,7 @@
   imports = [
     inputs.srvos.nixosModules.hardware-hetzner-online-amd
     inputs.self.nixosModules.common
+    inputs.self.nixosModules.builder
     inputs.self.nixosModules.zfs
     inputs.self.nixosModules.community-builder
   ];

--- a/hosts/build02/configuration.nix
+++ b/hosts/build02/configuration.nix
@@ -7,6 +7,7 @@
     ./nixpkgs-update.nix
     ./nixpkgs-update-backup.nix
     inputs.self.nixosModules.common
+    inputs.self.nixosModules.builder
     inputs.self.nixosModules.hercules-ci
     inputs.self.nixosModules.zfs
   ];

--- a/hosts/build03/configuration.nix
+++ b/hosts/build03/configuration.nix
@@ -13,6 +13,7 @@
     inputs.srvos.nixosModules.mixins-nginx
     inputs.srvos.nixosModules.hardware-hetzner-online-amd
     inputs.self.nixosModules.common
+    inputs.self.nixosModules.builder
     inputs.self.nixosModules.hercules-ci
     inputs.self.nixosModules.watch-store
     inputs.self.nixosModules.zfs

--- a/hosts/build04/configuration.nix
+++ b/hosts/build04/configuration.nix
@@ -4,6 +4,7 @@
     inputs.disko.nixosModules.disko
     ./hardware-configuration.nix
     inputs.self.nixosModules.common
+    inputs.self.nixosModules.builder
     inputs.self.nixosModules.hercules-ci
     inputs.self.nixosModules.remote-builder
   ];

--- a/hosts/darwin02/configuration.nix
+++ b/hosts/darwin02/configuration.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     inputs.self.darwinModules.common
+    inputs.self.darwinModules.builder
     inputs.self.darwinModules.hercules-ci
     inputs.self.darwinModules.remote-builder
   ];

--- a/hosts/darwin03/configuration.nix
+++ b/hosts/darwin03/configuration.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     inputs.self.darwinModules.common
+    inputs.self.darwinModules.builder
     inputs.self.darwinModules.hercules-ci
     inputs.self.darwinModules.remote-builder
   ];

--- a/modules/darwin/builder.nix
+++ b/modules/darwin/builder.nix
@@ -1,0 +1,7 @@
+{
+  imports = [
+    ../shared/builder.nix
+  ];
+
+  nix.gc.interval = { Minute = 15; };
+}

--- a/modules/nixos/builder.nix
+++ b/modules/nixos/builder.nix
@@ -4,4 +4,9 @@
   ];
 
   nix.gc.dates = "hourly";
+
+  # Bump the open files limit so that non-root users can run NixOS VM tests
+  security.pam.loginLimits = [
+    { domain = "*"; item = "nofile"; type = "-"; value = "20480"; }
+  ];
 }

--- a/modules/nixos/builder.nix
+++ b/modules/nixos/builder.nix
@@ -1,0 +1,7 @@
+{
+  imports = [
+    ../shared/builder.nix
+  ];
+
+  nix.gc.dates = "hourly";
+}

--- a/modules/shared/builder.nix
+++ b/modules/shared/builder.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+let
+  asGB = size: toString (size * 1024 * 1024 * 1024);
+in
+{
+  nix.gc.options = ''
+    --max-freed "$((${asGB 50} * 1024**3 - 1024 * $(df -P -k /nix/store | tail -n 1 | ${pkgs.gawk}/bin/awk '{ print $4 }')))"
+  '';
+}

--- a/modules/shared/nix-daemon.nix
+++ b/modules/shared/nix-daemon.nix
@@ -17,8 +17,8 @@ in
     settings.auto-optimise-store = true;
 
     # auto-free the /nix/store
-    settings.min-free = asGB 10;
-    settings.max-free = asGB 200;
+    settings.min-free = asGB 30;
+    settings.max-free = asGB 50;
 
     # useful for ad-hoc nix-shell's for debugging
     # use mkForce to avoid search path warnings with nix-darwin

--- a/modules/shared/nix-daemon.nix
+++ b/modules/shared/nix-daemon.nix
@@ -25,6 +25,6 @@ in
     nixPath = pkgs.lib.mkForce [ "nixpkgs=${pkgs.path}" ];
 
     gc.automatic = true;
-    gc.options = "--delete-older-than 14d";
+    gc.options = pkgs.lib.mkDefault "--delete-older-than 14d";
   };
 }


### PR DESCRIPTION
Easier to review and merge the remote-builder module commit first in https://github.com/nix-community/infra/pull/815.
___
Noticed `loginLimits` in [nixos-org-configurations](https://github.com/NixOS/nixos-org-configurations/blob/3ca70f40caf1d5099b9382e2aa15ba863b8aad67/delft/common.nix#L70) when I was looking for their `nix.gc` config.

[srvos](https://github.com/numtide/srvos/blob/main/nixos/roles/nix-remote-builder.nix#L26) sets 20480 in the remote builder module so I'll use that.

---

min-free, max-free and max-freed numbers are from https://github.com/NixOS/nixos-org-configurations/blob/master/macs/nix-darwin.nix.