### PR TITLE
modules/shared/builder: fix max-freed size

### DIFF
--- a/modules/shared/builder.nix
+++ b/modules/shared/builder.nix
@@ -1,9 +1,6 @@
 { pkgs, ... }:
-let
-  asGB = size: toString (size * 1024 * 1024 * 1024);
-in
 {
   nix.gc.options = ''
-    --max-freed "$((${asGB 50} * 1024**3 - 1024 * $(df -P -k /nix/store | tail -n 1 | ${pkgs.gawk}/bin/awk '{ print $4 }')))"
+    --max-freed "$((50 * 1024**3 - 1024 * $(df -P -k /nix/store | tail -n 1 | ${pkgs.gawk}/bin/awk '{ print $4 }')))"
   '';
 }


### PR DESCRIPTION
Thought I'd already fixed this but must have reverted it when refactoring.