### PR TITLE
modules/nixos/monitoring/matrix-hook: use package from nixpkgs

### DIFF
--- a/modules/nixos/monitoring/matrix-hook.nix
+++ b/modules/nixos/monitoring/matrix-hook.nix
@@ -1,19 +1,6 @@
 { config, pkgs, ... }:
 let
-  matrixHook = pkgs.buildGoModule rec {
-    pname = "matrix-hook";
-    version = "2e2770e685ca57e111b9dd2dc178cc6984404a25";
-    src = pkgs.fetchFromGitHub {
-      owner = "pinpox";
-      repo = "matrix-hook";
-      rev = version;
-      hash = "sha256-G5pq9sIz94V2uTYBcuHJsqD2/pMtxhWkAO8B0FncLbE=";
-    };
-    vendorHash = "sha256-185Wz9IpJRBmunl+KGj/iy37YeszbT3UYzyk9V994oQ=";
-    postInstall = ''
-      install message.html.tmpl -Dt $out
-    '';
-  };
+  matrixHook = pkgs.matrix-hook;
 in
 {
   sops.secrets.nix-community-matrix-bot-token = { };


### PR DESCRIPTION
Should be able to merge this after tomorrows flake update.