### PR TITLE
modules/shared/remote-builder: use `restrict` for ssh

### DIFF
--- a/modules/shared/remote-builder.nix
+++ b/modules/shared/remote-builder.nix
@@ -6,7 +6,7 @@ in
 {
   users.users.nix.openssh.authorizedKeys.keys = [
     # use nix-store for hydra which doesn't support ssh-ng
-    ''command="${config.nix.package}/bin/nix-store --serve --write",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding ${key}''
+    ''restrict,command="${config.nix.package}/bin/nix-store --serve --write" ${key}''
   ];
 
   nix.settings.trusted-users = [ "nix" ];


### PR DESCRIPTION
> [restrict](https://man.openbsd.org/sshd.8#restrict)
    Enable all restrictions, i.e. disable port, agent and X11 forwarding, as well as disabling PTY allocation and execution of ~/.ssh/rc. If any future restriction capabilities are added to authorized_keys files, they will be included in this set.