### PR TITLE
modules/nixos/monitoring: put alertmanager behind basic_auth

### DIFF
--- a/hosts/web02/secrets.yaml
+++ b/hosts/web02/secrets.yaml
@@ -2,6 +2,8 @@ ssh_host_ed25519_key: ENC[AES256_GCM,data:mp33XErF8FL7/rxKUsXiVijkCcDlSmtopkxTA/
 nix-community-matrix-bot-token: ENC[AES256_GCM,data:CHL3h0ttoBjj5xGfvQ9k4kYDMFdKV9V5DV9KOtz84LotVjZ7MRP9LDjvxfchO8T3kU1OMPWqBVYOS04da3xMLyRQRa1phkkGwjigjQ==,iv:pGyD4w4LLYfZmyZol52DTKeWMOniG96TX0aoF/4/uxM=,tag:Hw/eCheMjiUBj9bDTz0Ysw==,type:str]
 grafana-admin-password: ENC[AES256_GCM,data:imowUQJxi03QyhYBvMx8nWo6VvblOSaQ3YozWyl4w86cEQ==,iv:Pop10QAd9rSwwyXzhvfmIr+bCKOCEaVGTcvg7VH5BTo=,tag:eRJ8N9M/iaIC2rx5MFfsEw==,type:str]
 grafana-client-secret: ENC[AES256_GCM,data:ET2/XYYDTPuZtmQvvmxqFSVini+z4ap3hQfdkLKOMikFvHNzhEgHzw==,iv:JLM490Da0bDohB4Rm38c1eeKYlM4ODL+Loth9i/RPC8=,tag:3uepHgyot9EgUKPQqYWHBQ==,type:str]
+nginx-basic-auth-file: ENC[AES256_GCM,data:andS+j0bOp4m7Xty1RuAmyNGz36rUChhl4dtY+mvguHzei2lYDfdZWilx2VUFT5mmsWCeyrT5otVVg==,iv:BuawT6dsaI6s/vXbfG2HijUBzHec2D47w8KRj6Bba2Y=,tag:PjkfdKhjWmP6+NKFGEPijg==,type:str]
+nginx-basic-auth-password: ENC[AES256_GCM,data:ne6h4KoBo7dNkrKhe4thFkgE/EmIOkfzDh0Bag==,iv:ZsHANsb6PI4a84K81fM1PHtPPa0mi8nYLfh1A9CbaqY=,tag:IYQyFasarwh/EPZ3iUNX3Q==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -62,8 +64,8 @@ sops:
             QnJZZzN1a1M5b1dwa3hvL3ZHYkpxQUkK1g9sQB0UHl9coaznjIn4WDpQv21Y8cl9
             LNqnv0Q6KrxNliq2JEJoEpjD5+xTcqV/5FgylKhtdNWUZ0eAX8taog==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-09-17T00:19:44Z"
-    mac: ENC[AES256_GCM,data:hu48nar/2Z2HrBopQ2cbeucqq+rbE4OqBVCaLNdldIukJza0GWD7kMkBNXciM6J8BkfxFwcFSDBnieth9N/4tEu8ssorCZmnG9VUioNL/dbNVMTAgBTSc+BTgcNg9jTRea0y82OCEqAAxzEFSwDi2uAkzuecoFu6de3sVmYOUsc=,iv:O9V9c6EW942bn4IIfX+UFU/2cYu2eKCOxQ3PFcXSEYA=,tag:IplW3Em3yulcKQeySzP3LQ==,type:str]
+    lastmodified: "2023-09-26T21:36:16Z"
+    mac: ENC[AES256_GCM,data:/xlC4fSWefTFADQAM/fXEiZfYhuPMsPdze7yXSgIlK3zRPj453BxkhxfKdTgE8shmY3Cdgw+SiLiygz3numAIdCJUbz5vFoByRoXk3L4cFFHx7CQKtEJ3IZAAix5hgGIbs4W0RB71AEuXxTMQKw0DFmpucvXqzriY2dOeCjhhGo=,iv:6fxA/gXCyYIEukrrRoRQI+0IR0DrUDvTrBzAZOlEvIQ=,tag:sGzxF4Q7N2ASLuoi/YWwJA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.3
+    version: 3.8.0

--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -1,3 +1,4 @@
+{ config, ... }:
 {
   imports = [
     ./grafana.nix
@@ -6,11 +7,16 @@
     ./telegraf.nix
   ];
 
+  sops.secrets.nginx-basic-auth-file.owner = "nginx";
+
   services.nginx.virtualHosts."monitoring.nix-community.org" = {
     enableACME = true;
     forceSSL = true;
     locations."/".return = "302 https://nix-community.org/monitoring";
-    locations."/alertmanager/".proxyPass = "http://localhost:9093/";
+    locations."/alertmanager/" = {
+      basicAuthFile = config.sops.secrets.nginx-basic-auth-file.path;
+      proxyPass = "http://localhost:9093/";
+    };
     locations."/grafana/" = {
       proxyPass = "http://localhost:3000/";
       proxyWebsockets = true;


### PR DESCRIPTION
We'd need to do this for loki so we may as well use it for alertmanager as well.