### PR TITLE
ignore direnv globally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ result-*
 # Terraform
 .terraform
 .terraform.*
-/terraform/.direnv
 
 # needed for treefmt
 !.github
 !.sops.yaml
+
+# direnv
+.direnv/


### PR DESCRIPTION
Why
===
* When I entered the directory, a .direnv directory was created and it was not ignored

What changed
===
* Ignore .direnv globally
* Remove now unneeded terraform directory ignore for direnv