### PR TITLE
build02/nixpkgs-update: make socat more patient

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -66,7 +66,7 @@ let
 
       msg=READY
       while true; do
-        response=$(echo "$msg" | socat UNIX-CONNECT:"$socket" - || true)
+        response=$(echo "$msg" | socat -t5 UNIX-CONNECT:"$socket" - || true)
         case "$response" in
           "") # connection error; retry
             sleep 5


### PR DESCRIPTION
This may address the intermittent ConnectionResetErrors we're seeing from the supervisor. By default, socat will terminate its connection to one side half a second after the other side closes; if the supervisor is taking more than half a second to respond, this results in dropped jobs. Bumping this timeout to five seconds should help.