### PR TITLE
Revert "disable buildbot nixos test for now"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,8 +67,7 @@
             };
 
             checks = pkgs.lib.optionalAttrs defaultPlatform {
-              # FIXME: this doesn't evaluate with pure evaluation yet.
-              #nixosTests-buildbot = release.tests.buildbot;
+              nixosTests-buildbot = pkgs.nixosTests.buildbot;
               nixosTests-hydra = pkgs.nixosTests.hydra.hydra_unstable;
               nixosTests-lemmy = pkgs.nixosTests.lemmy;
               nixosTests-pict-rs = pkgs.nixosTests.pict-rs;


### PR DESCRIPTION
This reverts commit 7f7c0463177c3c8b7ad1c6dfd4c227bb34b750ef.

https://github.com/NixOS/nixpkgs/pull/261159