### PR TITLE
.github/workflows: remove `update-flake-lock` token 

### DIFF
--- a/.github/workflows/flake-updates-nixpkgs-update.yml
+++ b/.github/workflows/flake-updates-nixpkgs-update.yml
@@ -16,7 +16,6 @@ jobs:
         id: update
         uses: DeterminateSystems/update-flake-lock@v20
         with:
-          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
           inputs: nixpkgs-update
       - name: Enable Automerge
         run: gh pr merge --rebase --auto "${{ steps.update.outputs.pull-request-number }}"

--- a/.github/workflows/flake-updates.yml
+++ b/.github/workflows/flake-updates.yml
@@ -17,8 +17,7 @@ jobs:
       - name: Update flake.lock
         id: update
         uses: DeterminateSystems/update-flake-lock@v20
-      # disable temporarily, can be reenabled when hercules fork action is removed
-      #- name: Enable Automerge
-      #  run: gh pr merge --rebase --auto "${{ steps.update.outputs.pull-request-number }}"
-      #  env:
-      #    GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+      - name: Enable Automerge
+        run: gh pr merge --rebase --auto "${{ steps.update.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}

--- a/.github/workflows/flake-updates.yml
+++ b/.github/workflows/flake-updates.yml
@@ -17,8 +17,6 @@ jobs:
       - name: Update flake.lock
         id: update
         uses: DeterminateSystems/update-flake-lock@v20
-        with:
-          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
       # disable temporarily, can be reenabled when hercules fork action is removed
       #- name: Enable Automerge
       #  run: gh pr merge --rebase --auto "${{ steps.update.outputs.pull-request-number }}"


### PR DESCRIPTION
The hercules actions won't trigger now that the PR isn't open by a privileged token so we can re-enable automerge.