### PR TITLE
flake: nixpkgs-update: bump 'wait for ofborg' to 60 minutes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -82,15 +82,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1696908581,
-        "narHash": "sha256-JoIuKbMvmsDmkVYB1aNsDZJlqg6XfuYBoPUzTSvSy5Q=",
-        "owner": "ryantm",
+        "lastModified": 1698207498,
+        "narHash": "sha256-hUtpTifZX8eMRkQtctm9eZYs1s32GZTXjcCoVHvinpI=",
+        "owner": "qowoz",
         "repo": "nixpkgs-update",
-        "rev": "a3fd7a8a741015be0613c80e95e78a4853569f8e",
+        "rev": "e56e5760569fa308acdc4a9286c2054696be1ee4",
         "type": "github"
       },
       "original": {
-        "owner": "ryantm",
+        "owner": "qowoz",
+        "ref": "wait60",
         "repo": "nixpkgs-update",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
     # actually not used when using the modules but than nothing ever will try to fetch this nixpkgs variant
     srvos.inputs.nixpkgs.follows = "nixpkgs";
 
-    nixpkgs-update.url = "github:ryantm/nixpkgs-update";
+    nixpkgs-update.url = "github:qowoz/nixpkgs-update/wait60";
     nixpkgs-update.inputs.mmdoc.follows = "";
     nixpkgs-update-github-releases.url = "github:ryantm/nixpkgs-update-github-releases";
     nixpkgs-update-github-releases.flake = false;


### PR DESCRIPTION
https://github.com/ryantm/nixpkgs-update/pull/370

This has been deploy on build02 for a week.