### PR TITLE
flake: cachix-deploy-spec: only deploy darwin03

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,8 +76,10 @@
 
             packages = pkgs.lib.optionalAttrs defaultPlatform {
               cachix-deploy-spec = pkgs.writeText "cachix-deploy.json" (builtins.toJSON {
-                agents =
-                  pkgs.lib.mapAttrs (_: darwin: builtins.unsafeDiscardStringContext darwin.config.system.build.toplevel) self.darwinConfigurations;
+                agents = {
+                  # hercules-ci-agent IFD breaks darwin02
+                  darwin03 = builtins.unsafeDiscardStringContext self.darwinConfigurations.darwin03.config.system.build.toplevel;
+                };
               });
               pages = pkgs.runCommand "pages"
                 {


### PR DESCRIPTION
Could remove the hercules agent from `darwin02` by using the new `remotePlatformsWithSameFeatures` hercules feature but that would be trading CI performance for admin convenience.