### PR TITLE
modules/darwin/community-builder: add user

### DIFF
--- a/modules/darwin/community-builder/keys/anthonyroussel
+++ b/modules/darwin/community-builder/keys/anthonyroussel
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPpyKOnpnayaNeMpNq1URpwBv69yb9m8vUl3ImxnsBOX anthonyroussel@darwin-build-box

--- a/modules/darwin/community-builder/users.nix
+++ b/modules/darwin/community-builder/users.nix
@@ -103,6 +103,11 @@ let
       trusted = true;
       uid = 543;
     }
+    {
+      name = "anthonyroussel";
+      trusted = true;
+      uid = 544;
+    }
   ];
 in
 {


### PR DESCRIPTION
Hello!

I [contribute regularly to nixpkgs](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+author%3Aanthonyroussel), but I don't own any MacOS workstation to test the builds of the packages I add to nixpkgs.

I would like to use this build box to test that my changes build fine on Darwin, and help improve Darwin support for nixpkgs :)

Is it possible to be added to the darwin build box?