### PR TITLE
docs/continuous-integration: add buildbot

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -7,17 +7,27 @@ We provide CI for these platforms:
 
 We only have limited build capacity for `*-darwin` and `aarch64-linux` so please don't use it excessively.
 
+#### Buildbot
+
+[https://buildbot.nix-community.org](https://buildbot.nix-community.org)
+
+_Buildbot is the only CI system that supports pull requests from forked repositories._
+
+To enable buildbot add the [`nix-community-buildbot`](https://github.com/topics/nix-community-buildbot) topic to the repository.
+
+_Newly enabled repos are imported into buildbot twice a day, you can also ask the admins to trigger an import manually._
+
 #### Hercules
 
 [https://hercules-ci.com/github/nix-community](https://hercules-ci.com/github/nix-community)
 
-To enable hercules builds go to `https://hercules-ci.com/github/nix-community/$REPO` and click "Build this repository".
+To enable hercules go to `https://hercules-ci.com/github/nix-community/$REPO` and click "Build this repository".
 
 #### Hydra
 
 [https://hydra.nix-community.org](https://hydra.nix-community.org)
 
-To enable hydra builds add a new project in this [file](https://github.com/nix-community/infra/blob/master/terraform/hydra-projects.tf).
+To enable hydra add a new project in this [file](https://github.com/nix-community/infra/blob/master/terraform/hydra-projects.tf).
 
 #### Faster GitHub Actions
 


### PR DESCRIPTION
We've run a bunch of builds here and in srvos without any issues so should be fine to advertise this now.