### PR TITLE
flake: unpin buildbot-nix

### DIFF
--- a/.github/workflows/flake-updates.yml
+++ b/.github/workflows/flake-updates.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Update flake.lock
         id: update
         uses: DeterminateSystems/update-flake-lock@v20
-      - name: Enable Automerge
-        run: gh pr merge --rebase --auto "${{ steps.update.outputs.pull-request-number }}"
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+      #- name: Enable Automerge
+      #  run: gh pr merge --rebase --auto "${{ steps.update.outputs.pull-request-number }}"
+      #  env:
+      #    GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}

--- a/flake.lock
+++ b/flake.lock
@@ -13,17 +13,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1699096834,
-        "narHash": "sha256-e25Mt5yoc7JUERqhvDaw58mh2DQiz0h4YPb0fO/i7G8=",
+        "lastModified": 1699102494,
+        "narHash": "sha256-tHK/Qnj05IXKO1KVDp3GfVi1taeSDUOgSsahX8b5SFY=",
         "owner": "Mic92",
         "repo": "buildbot-nix",
-        "rev": "3bf9f399f9b55b1d530be2b25c4f3799c74554eb",
+        "rev": "9884c25e94840bc733d7c26d720bca2decf7c640",
         "type": "github"
       },
       "original": {
         "owner": "Mic92",
         "repo": "buildbot-nix",
-        "rev": "3bf9f399f9b55b1d530be2b25c4f3799c74554eb",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     nixpkgs-update-github-releases.url = "github:ryantm/nixpkgs-update-github-releases";
     nixpkgs-update-github-releases.flake = false;
 
-    buildbot-nix.url = "github:Mic92/buildbot-nix/3bf9f399f9b55b1d530be2b25c4f3799c74554eb";
+    buildbot-nix.url = "github:Mic92/buildbot-nix";
     buildbot-nix.inputs.nixpkgs.follows = "nixpkgs";
     buildbot-nix.inputs.flake-parts.follows = "flake-parts";
     buildbot-nix.inputs.treefmt-nix.follows = "treefmt-nix";

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
           inputs.treefmt-nix.flakeModule
         ];
 
-        perSystem = { config, lib, pkgs, self', system, ... }:
+        perSystem = { config, inputs', lib, pkgs, self', system, ... }:
           let
             defaultPlatform = pkgs.stdenv.hostPlatform.system == "x86_64-linux";
           in
@@ -82,6 +82,8 @@
               darwinConfigurations // devShells // { inherit (self') formatter; } // nixosConfigurations // packages
               // pkgs.lib.optionalAttrs defaultPlatform {
                 nixosTests-buildbot = pkgs.nixosTests.buildbot;
+                nixosTests-buildbot-nix-master = inputs'.buildbot-nix.checks.master;
+                nixosTests-buildbot-nix-worker = inputs'.buildbot-nix.checks.worker;
                 nixosTests-hydra = pkgs.nixosTests.hydra.hydra_unstable;
                 #nixosTests-lemmy = pkgs.nixosTests.lemmy;
                 nixosTests-pict-rs = pkgs.nixosTests.pict-rs;


### PR DESCRIPTION
Unpinning `buildbot-nix` so picking up trivial updates is easier but disabling the automerge to ensure changes are reviewed.