### PR TITLE
doc/continuous-integration: separate namespace actions from self hosted

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -19,14 +19,6 @@ To enable hercules builds go to `https://hercules-ci.com/github/nix-community/$R
 
 To enable hydra builds add a new project in this [file](https://github.com/nix-community/infra/blob/master/terraform/hydra-projects.tf).
 
-#### Faster GitHub Actions
-
-[namespace](https://cloud.namespace.so) is providing us with Faster GitHub Actions, including ARM64 builders.
-
-Doc: <https://cloud.namespace.so/docs/features/faster-github-actions>.
-
-Limits: see the "Team plan" on <https://cloud.namespace.so/pricing>
-
 #### Cache
 
 [https://nix-community.cachix.org/](https://nix-community.cachix.org/)

--- a/docs/namespace-actions.md
+++ b/docs/namespace-actions.md
@@ -1,0 +1,5 @@
+[namespace](https://cloud.namespace.so) is providing us with Faster GitHub Actions, including ARM64 builders.
+
+Doc: <https://cloud.namespace.so/docs/features/faster-github-actions>.
+
+Limits: see the "Team plan" on <https://cloud.namespace.so/pricing>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ nav:
   - sponsors.md
   - Services:
       - continuous-integration.md
+      - Faster GitHub Actions: namespace-actions.md
       - community-builder.md
       - R. RyanTM update bot: update-bot.md
       - NUR update: nur-update.md


### PR DESCRIPTION
This makes the namespace actions a bit more prominent.