### PR TITLE
build02/nixpkgs-update: add timeout for workers

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -59,8 +59,11 @@ let
       function run-nixpkgs-update {
         exit_code=0
         set -x
-        ${nixpkgs-update-bin} update-batch --pr --outpaths --nixpkgs-review "$attr_path $payload" || exit_code=$?
+        timeout 12h ${nixpkgs-update-bin} update-batch --pr --outpaths --nixpkgs-review "$attr_path $payload" || exit_code=$?
         set +x
+        if [ $exit_code -eq 124 ]; then
+          echo "Update was interrupted because it was taking too long."
+        fi
         msg="DONE $attr_path $exit_code"
       }
 


### PR DESCRIPTION
This is intended to reduce the impact of incidents like #945.

Reviewing data from the last 23,000+ worker jobs that ran to completion, all but five packages finished in under two hours; the maximum was under eight. So a twelve-hour timeout is a fairly conservative starting point, I think.