### PR TITLE
modules/nixos/hydra: remove secret

### DIFF
--- a/modules/nixos/hydra.nix
+++ b/modules/nixos/hydra.nix
@@ -20,15 +20,10 @@
     sops.secrets.hydra-admin-password.owner = "hydra";
     sops.secrets.hydra-users.owner = "hydra";
 
-    # hydra-queue-runner needs to read this key for remote building
-    sops.secrets.id_buildfarm.owner = "hydra-queue-runner";
-
     nix.settings.allowed-uris = [
       "https://github.com/nix-community/"
       "https://github.com/NixOS/"
     ];
-
-    sops.secrets.id_buildfarm = { };
 
     # delete build logs older than 30 days
     systemd.services.hydra-delete-old-logs = {


### PR DESCRIPTION
Added in b1b2e2c7fe768f924805ede5b2898d1c0779f15e, I don't think this is needed now that the secret isn't accessed via `buildMachinesFiles`.