### PR TITLE
build02/nixpkgs-update: add another worker

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -191,8 +191,8 @@ in
 
   systemd.services.nixpkgs-update-worker1 = mkWorker "worker1";
   systemd.services.nixpkgs-update-worker2 = mkWorker "worker2";
+  systemd.services.nixpkgs-update-worker3 = mkWorker "worker3";
   # Too many workers cause out-of-memory.
-  #systemd.services.nixpkgs-update-worker3 = mkWorker "worker3";
   #systemd.services.nixpkgs-update-worker4 = mkWorker "worker4";
 
   systemd.services.nixpkgs-update-supervisor = {


### PR DESCRIPTION
Haven't tried this for a while, memory needed for evals may still be an issue.

With more projects using buildbot there is less need for another hercules agent. https://github.com/nix-community/infra/pull/990

Each nixpkgs-update worker is throttled to 1 PR an hour so adding another worker won't really make the ofborg situation much worse than it is currently but it will allow nixpkgs-update to process the updates much faster.