### PR TITLE
modules/nixos/buildbot: add `Upholds`

### DIFF
--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -38,6 +38,11 @@
     };
   };
 
+  systemd.targets.multi-user.unitConfig.Upholds = [
+    "buildbot-master.service"
+    "buildbot-worker.service"
+  ];
+
   sops.secrets.cachix-auth-token = { };
   sops.secrets.cachix-name = { };
 


### PR DESCRIPTION
Buildbot fails if it can't connect to github after the host is rebooted.