### PR TITLE
flake: remove nixpkgs-update nixConfig

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,9 @@
 
   nixConfig.extra-substituters = [
     "https://nix-community.cachix.org"
-    "https://nixpkgs-update.cachix.org"
   ];
   nixConfig.extra-trusted-public-keys = [
     "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-    "nixpkgs-update.cachix.org-1:6y6Z2JdoL3APdu6/+Iy8eZX2ajf09e4EE9SnxSML1W8="
   ];
 
   inputs = {


### PR DESCRIPTION
We only need this for the `nixpkgs-update` binary which is cheap for us to build anyway.

Removing this will get rid of a lot of the warnings in the buildbot eval logs.

Before: https://buildbot.nix-community.org/#/builders/6/builds/30/steps/2/logs/stdio

After: https://buildbot.nix-community.org/#/builders/6/builds/33/steps/2/logs/stdio