### PR TITLE
unpin terraform shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,7 +238,6 @@
         "nur-update": "nur-update",
         "sops-nix": "sops-nix",
         "srvos": "srvos",
-        "tf-pkgs": "tf-pkgs",
         "treefmt-nix": "treefmt-nix"
       }
     },
@@ -281,22 +280,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "srvos",
-        "type": "github"
-      }
-    },
-    "tf-pkgs": {
-      "locked": {
-        "lastModified": 1697343899,
-        "narHash": "sha256-66Dosy7YYVhkesbHXB4xxZZ+2NOi9CmFDyHOI1ZTAbQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "982b24c40e743793c966b47b3bb3699881489ae0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "982b24c40e743793c966b47b3bb3699881489ae0",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -41,8 +41,6 @@
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
 
-    tf-pkgs.url = "github:NixOS/nixpkgs/982b24c40e743793c966b47b3bb3699881489ae0";
-
     hercules-ci-agent.url = "github:hercules-ci/hercules-ci-agent";
     hercules-ci-agent.inputs.flake-parts.follows = "flake-parts";
     #hercules-ci-agent.inputs.nixpkgs.follows = "nixpkgs";

--- a/tasks.py
+++ b/tasks.py
@@ -90,27 +90,6 @@ def print_keys(c: Any, flake_attr: str) -> None:
 
 
 @task
-def update_terraform(c: Any) -> None:
-    """
-    Update terraform devshell flake
-    """
-    c.run(
-        """
-system="$(nix eval --impure --raw --expr 'builtins.currentSystem')"
-oldShell="$(nix build --no-link --print-out-paths ".#devShells.${system}.terraform")"
-oldRev="$(nix flake metadata --json | jq -r '.locks.nodes."tf-pkgs".locked.rev')"
-newRev="$(nix flake metadata --json | jq -r '.locks.nodes.nixpkgs.locked.rev')"
-sed -i "s|${oldRev}|${newRev}|" flake.nix
-nix flake lock --update-input tf-pkgs --commit-lock-file
-newShell="$(nix build --no-link --print-out-paths ".#devShells.${system}.terraform")"
-commit="$(git log --pretty=format:%B -1)"
-diff="$(nix store diff-closures "${oldShell}" "${newShell}" | awk -F ',' '/terraform/ && /→/ {print $1}')"
-git commit --all --amend -m "${commit}" -m "Terraform updates:" -m "${diff}"
-"""
-    )
-
-
-@task
 def mkdocs(c: Any) -> None:
     """
     Serve docs (mkdoc serve)

--- a/terraform/shell.nix
+++ b/terraform/shell.nix
@@ -1,11 +1,10 @@
-{ inputs', ... }:
+{ pkgs, ... }:
 let
-  tf-pkgs = inputs'.tf-pkgs.legacyPackages;
-  terraform' = tf-pkgs.terraform.overrideAttrs (_: { meta = { }; });
+  terraform' = pkgs.terraform.overrideAttrs (_: { meta = { }; });
 in
 {
   devShells = {
-    terraform = with tf-pkgs; mkShellNoCC {
+    terraform = with pkgs; mkShellNoCC {
       packages = [
         (terraform'.withPlugins (p: [
           p.cloudflare


### PR DESCRIPTION
We likely won't return to running terraform automatically on CI for a while, if ever.

Don't really need the pin for manual use so we may as well save ourselves an extra input.