### PR TITLE
modules/darwin/common/flake-inputs: fix inputs

### DIFF
--- a/modules/darwin/common/flake-inputs.nix
+++ b/modules/darwin/common/flake-inputs.nix
@@ -3,7 +3,7 @@
 {
   services.telegraf.extraConfig.inputs.file =
     let
-      inputsWithDate = lib.filterAttrs (_: input: input ? lastModified) inputs;
+      inputsWithDate = lib.filterAttrs (_: input: input ? lastModified) inputs.self.inputs;
       flakeAttrs = input: (lib.mapAttrsToList (n: v: ''${n}="${v}"'')
         (lib.filterAttrs (_: v: (builtins.typeOf v) == "string") input));
       lastModified = name: input: ''


### PR DESCRIPTION
This was causing unnecessary rebuilds.