### PR TITLE
modules/nixos/hydra: update allowed-uris

### DIFF
--- a/modules/nixos/hydra.nix
+++ b/modules/nixos/hydra.nix
@@ -5,8 +5,11 @@
     sops.secrets.hydra-users.owner = "hydra";
 
     nix.settings.allowed-uris = [
-      "https://github.com/nix-community/"
-      "https://github.com/NixOS/"
+      "git+https:"
+      "github:"
+      "gitlab:"
+      "https:"
+      "sourcehut:"
     ];
 
     # delete build logs older than 30 days

--- a/modules/nixos/hydra.nix
+++ b/modules/nixos/hydra.nix
@@ -17,19 +17,6 @@
 
     services.hydra = {
       enable = true;
-
-      package = (pkgs.hydra_unstable.override {
-        nix = pkgs.nixVersions.nix_2_18;
-      }).overrideAttrs (_: {
-        version = "2023-12-01";
-        src = pkgs.fetchFromGitHub {
-          owner = "NixOS";
-          repo = "hydra";
-          rev = "4d1c8505120961f10897b8fe9a070d4e193c9a13";
-          hash = "sha256-vXTuE83GL15mgZHegbllVAsVdDFcWWSayPfZxTJN5ys=";
-        };
-      });
-
       # remote builders set in /etc/nix/machines + localhost
       buildMachinesFiles = [
         "/etc/nix/machines"


### PR DESCRIPTION
Waiting for nix 2.19.3 or 2.20 and for the nixpkgs hydra to be updated to use that version.