### PR TITLE
modules/nixos/common/security: drop fail2ban

### DIFF
--- a/modules/nixos/common/security.nix
+++ b/modules/nixos/common/security.nix
@@ -42,7 +42,4 @@
       { path = "/etc/ssh/ssh_host_ed25519_key"; type = "ed25519"; }
     ];
   };
-
-  # Ban brute force SSH
-  #services.fail2ban.enable = true;
 }


### PR DESCRIPTION
We only allow publickey auth so this is only of limited value anyway.

It has been disabled for the last couple of months as the nixpkgs module was broken and I forgot to re-enable it.