### PR TITLE
build01,build02,build03: remove hostId

### DIFF
--- a/hosts/build01/configuration.nix
+++ b/hosts/build01/configuration.nix
@@ -13,7 +13,6 @@
   boot.binfmt.emulatedSystems = [ "riscv64-linux" ];
 
   networking.hostName = "build01";
-  networking.hostId = "d2905767";
 
   systemd.network.networks."10-uplink".networkConfig.Address = "2a01:4f9:3a:3b16::1/64";
 

--- a/hosts/build02/configuration.nix
+++ b/hosts/build02/configuration.nix
@@ -14,7 +14,6 @@
   nixCommunity.disko.raidLevel = 0; # more disk space, we don't have much state to restore anyway
 
   networking.hostName = "build02";
-  networking.hostId = "af9ccc71";
   networking.nameservers = [ "1.1.1.1" "1.0.0.1" ];
 
   systemd.network.networks."10-uplink".networkConfig.Address = "2a01:4f9:3b:41d9::1";

--- a/hosts/build03/configuration.nix
+++ b/hosts/build03/configuration.nix
@@ -20,7 +20,6 @@
   systemd.network.networks."10-uplink".networkConfig.Address = "2a01:4f9:3b:2946::1/64";
 
   networking.hostName = "build03";
-  networking.hostId = "8daf74c0";
 
   system.stateVersion = "23.11";
 }


### PR DESCRIPTION
This was needed for zfs which we aren't using on these hosts.