### PR TITLE
terraform/terraform_cloud: switch to `tfe_workspace_settings`

### DIFF
--- a/terraform/terraform_cloud.tf
+++ b/terraform/terraform_cloud.tf
@@ -40,8 +40,12 @@ resource "tfe_team_organization_member" "owners" {
 
 # For new we only have one workspace that contains everything
 resource "tfe_workspace" "nix-community" {
-  name           = "nix-community"
-  organization   = local.tfe_org
-  description    = ""
+  name         = "nix-community"
+  organization = local.tfe_org
+  description  = ""
+}
+
+resource "tfe_workspace_settings" "nix-community-settings" {
+  workspace_id   = tfe_workspace.nix-community.id
   execution_mode = "local" # only use it to hold state
 }


### PR DESCRIPTION
```
╷
│ Warning: Argument is deprecated
│
│   with tfe_workspace.nix-community,
│   on terraform_cloud.tf line 46, in resource "tfe_workspace" "nix-community":
│   46:   execution_mode = "local" # only use it to hold state
│
│ Use resource tfe_workspace_settings to modify the workspace execution settings. This attribute
│ will be removed in a future release of the provider.
│
│ (and one more similar warning elsewhere)
╵
```