### PR TITLE
modules/nixos/common: use latest kernel

### DIFF
--- a/modules/nixos/common/default.nix
+++ b/modules/nixos/common/default.nix
@@ -1,4 +1,4 @@
-{ inputs, ... }:
+{ inputs, pkgs, ... }:
 {
   imports = [
     ./auto-upgrade.nix
@@ -26,6 +26,8 @@
   networking.firewall.allowedTCPPorts = [ 9273 ];
 
   srvos.flake = inputs.self;
+
+  boot.kernelPackages = pkgs.linuxPackages_latest;
 
   zramSwap.enable = true;
 


### PR DESCRIPTION
https://github.com/nix-community/infra/commit/f3967527610aebf42793a6553a73eb8ad5601876

Now we're not using zfs we can go back to using the latest kernel. 