### PR TITLE
modules/nixos/buildbot: use wheel members as admins

### DIFF
--- a/devdoc/onboarding.md
+++ b/devdoc/onboarding.md
@@ -4,8 +4,6 @@
 
 - Add their user and ssh key to [users](../users) as member of the `trusted` and `wheel` groups.
 
-- Add their user to the list of `admins` in [modules/nixos/buildbot.nix](../modules/nixos/buildbot.nix).
-
 - Add their age key to [.sops.yaml](../.sops.yaml), update the `creation_rules` and run `inv update-sops-files`.
 
 - Make them a `owner` of the [nix-community GitHub organisation](https://github.com/nix-community) and a member of the [nix-community GitHub `admin` team](https://github.com/orgs/nix-community/teams/admin/members).

--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -37,7 +37,7 @@
       oauthSecretFile = config.sops.secrets.buildbot-github-oauth-secret.path;
       oauthId = "9bbd3e8bbfebb197d2ca";
       user = "nix-community-buildbot";
-      admins = [ "adisbladis" "Mic92" "ryantm" "zimbatm" "zowoq" ];
+      admins = config.users.groups.wheel.members;
       topic = "nix-community-buildbot";
     };
   };


### PR DESCRIPTION
~~I guess this would be a problem if a future admin wanted to have a username different from their github but maybe that doesn't happen?~~

Probably easier to just leave this as is, might look at adding support to buildbot for teams as well so we can use `@nix-community/admin` here.