### PR TITLE
modules/nixos/monitoring/prometheus: set retention time to 30 days

### DIFF
--- a/modules/nixos/monitoring/prometheus.nix
+++ b/modules/nixos/monitoring/prometheus.nix
@@ -8,7 +8,7 @@
     enable = true;
     checkConfig = true;
     webExternalUrl = "https://monitoring.nix-community.org/prometheus/";
-    extraFlags = [ "--web.route-prefix=/" ];
+    extraFlags = [ "--storage.tsdb.retention.time=30d" "--web.route-prefix=/" ];
     scrapeConfigs = [
       {
         job_name = "telegraf";


### PR DESCRIPTION
Having more than two weeks of data is sometimes helpful.