### PR TITLE
modules/*/reboot: reduce window from 6 to 3 hours

### DIFF
--- a/modules/darwin/common/reboot.nix
+++ b/modules/darwin/common/reboot.nix
@@ -1,9 +1,9 @@
 {
-  # reboot every sunday between 00:00 and 06:00
+  # reboot every sunday between 00:00 and 03:00
   launchd.daemons.reboot = {
     script = ''
       date
-      /sbin/shutdown -r "+$(( $RANDOM % ( 6 * 60 ) ))"
+      /sbin/shutdown -r "+$(( $RANDOM % ( 3 * 60 ) ))"
     '';
     serviceConfig = {
       StartCalendarInterval = [

--- a/modules/nixos/common/reboot.nix
+++ b/modules/nixos/common/reboot.nix
@@ -12,9 +12,9 @@
         ${config.systemd.package}/bin/shutdown -r now
       fi
     '';
-    startAt = "0/6:00";
+    startAt = "0/3:00";
   };
   systemd.timers.reboot-after-update = {
-    timerConfig.RandomizedDelaySec = "6h";
+    timerConfig.RandomizedDelaySec = "3h";
   };
 }


### PR DESCRIPTION
The original intent was just to make sure that all of the machines didn't reboot at the same time, three hour window will still do that and is a little bit more convenient to monitor.

