### PR TITLE
modules/darwin/common: only allow ssh_host_ed25519_key

### DIFF
--- a/modules/darwin/common/default.nix
+++ b/modules/darwin/common/default.nix
@@ -60,6 +60,7 @@
 
   # srvos
   environment.etc."ssh/sshd_config.d/darwin.conf".text = ''
+    HostKey /etc/ssh/ssh_host_ed25519_key
     KbdInteractiveAuthentication no
     PasswordAuthentication no
     StrictModes no


### PR DESCRIPTION
81dd4e0557c2a5a9e59a3b1546f098044f18b61b
we do the same for nixos