### PR TITLE
build02/nixpkgs-update: remove logs older than 18 months

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -231,6 +231,15 @@ in
     '';
   };
 
+  systemd.services.nixpkgs-update-delete-old-logs = {
+    startAt = "weekly";
+    # delete logs older than 18 months, delete empty directories
+    serviceConfig.script = ''
+      ${pkgs.findutils}/bin/find /var/log/nixpkgs-update -type f -mtime +548 -delete
+      ${pkgs.findutils}/bin/find /var/log/nixpkgs-update -type d -empty -delete
+    '';
+  };
+
   systemd.tmpfiles.rules = [
     "L+ /home/r-ryantm/.gitconfig - - - - ${./gitconfig.txt}"
     "d /home/r-ryantm/.ssh 700 r-ryantm r-ryantm - -"


### PR DESCRIPTION
Mostly just want to remove cruft, e.g. deleted packages, outdated package sets. I think 18 months is a reasonable window?

cc @rhendric 

Copied service from:
https://github.com/nix-community/infra/blob/6a302a08cb0ffae537caacaa85f89fea9d340bbf/modules/nixos/hydra.nix#L15-L19