### PR TITLE
build02/nixpkgs-update: reduce timeout to six hours

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -60,7 +60,7 @@ let
       function run-nixpkgs-update {
         exit_code=0
         set -x
-        timeout 12h ${nixpkgs-update-bin} update-batch --pr --outpaths --nixpkgs-review "$attr_path $payload" || exit_code=$?
+        timeout 6h ${nixpkgs-update-bin} update-batch --pr --outpaths --nixpkgs-review "$attr_path $payload" || exit_code=$?
         set +x
         if [ $exit_code -eq 124 ]; then
           echo "Update was interrupted because it was taking too long."


### PR DESCRIPTION
A few times I'll restarted workers that have been stuck for 3+ hours, not much point it letting it run until it hits the 12 hour timeout.

https://github.com/nix-community/infra/pull/951

6 hours seems to cover almost everything, after a couple of weeks we can review the logs, fix/disable problem packages or increase the timeout if necessary?

cc @rhendric 