### PR TITLE
modules/nixos/disko-raid: add option for filesystem type

### DIFF
--- a/modules/nixos/disko-raid.nix
+++ b/modules/nixos/disko-raid.nix
@@ -36,6 +36,11 @@ in
     inputs.disko.nixosModules.disko
   ];
   options = {
+    nixCommunity.disko.fsType = lib.mkOption {
+      type = lib.types.enum [ "btrfs" "ext4" ];
+      default = "ext4";
+      description = "Type of filesystem to use";
+    };
     nixCommunity.disko.raidLevel = lib.mkOption {
       type = lib.types.int;
       default = 1;
@@ -65,7 +70,7 @@ in
         level = config.nixCommunity.disko.raidLevel;
         content = {
           type = "filesystem";
-          format = "ext4";
+          format = config.nixCommunity.disko.fsType;
           mountpoint = "/";
         };
       };


### PR DESCRIPTION
Will switch to xfs on build02 to address the inode problems, would seem to be the simplest option.

- don't really want to go back to zfs and being limited to which kernels we can use. (we also seem to have had high memory usage with zfs.)
- bcachefs is a bit too new. (also disko doesn't have support for bcache multi-disk yet).
- btrfs might be okay but disko doesn't have support for multi-disk yet.