### PR TITLE
build02/nixpkgs-update: run fetchers every 12 hours

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -132,13 +132,14 @@ let
     script = ''
       mkdir -p "$LOGS_DIRECTORY/~fetchers"
       cd "$LOGS_DIRECTORY/~fetchers"
+      sleep 60 # wait for network
       while true; do
         run_name="${name}.$(date +%s).txt"
         rm -f ${name}.*.txt.part
         ${cmd} > "$run_name.part"
         rm -f ${name}.*.txt
         mv "$run_name.part" "$run_name"
-        sleep 24h
+        sleep 12h
       done
     '';
   };


### PR DESCRIPTION
Spread out new github and repology PRs a little instead of batching them once a day.

I think twice a day should be fine but probably need to check API ratelimits to increase it any further.

cc @rhendric 