### PR TITLE
build02/nixpkgs-update: add another worker

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -199,6 +199,7 @@ in
   systemd.services.nixpkgs-update-worker3 = mkWorker "worker3";
   systemd.services.nixpkgs-update-worker4 = mkWorker "worker4";
   systemd.services.nixpkgs-update-worker5 = mkWorker "worker5";
+  systemd.services.nixpkgs-update-worker6 = mkWorker "worker6";
   # Too many workers cause out-of-memory.
 
   systemd.services.nixpkgs-update-supervisor = {


### PR DESCRIPTION
Deployed this manually, will let it run for a bit to see what memory usage is like and if ofborg will keep up.

Might need to reconsider the 45m timeout for nixpkgs-review when running this many workers, could possibly have all of them running at once.

Update: will just add one extra worker for now, that may be enough.