### PR TITLE
darwin: disable netbios on activation

### DIFF
--- a/modules/darwin/common/default.nix
+++ b/modules/darwin/common/default.nix
@@ -66,5 +66,12 @@
     StrictModes no
   '';
 
+  # Make sure to disable netbios on activation
+  system.activationScripts.postActivation.text = ''
+    echo disabling netbios... >&2
+    launchctl disable system/netbiosd
+    launchctl unload -w /System/Library/LaunchDaemons/com.apple.netbiosd.plist 2>/dev/null || true
+  '';
+
   time.timeZone = "GMT";
 }


### PR DESCRIPTION
We have received a notification from the German Federal Office for Information Security (BSI) about our NetBIOS being enabled, and it potentially being used for DDoS reflection attacks.