### PR TITLE
flake: pin nixpkgs for darwin01 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,6 +102,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-darwin-pinned": {
+      "locked": {
+        "lastModified": 1710339354,
+        "narHash": "sha256-+P5ccUPiLouHexb8aJrUOVOIja9qm+fG57pgAu7uIRs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2dbc8f62d8af7a1ab962e4b20d12b25ddcb86ced",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2dbc8f62d8af7a1ab962e4b20d12b25ddcb86ced",
+        "type": "github"
+      }
+    },
     "nixpkgs-update": {
       "inputs": {
         "mmdoc": [],
@@ -183,6 +199,7 @@
         "flake-parts": "flake-parts",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-darwin-pinned": "nixpkgs-darwin-pinned",
         "nixpkgs-update": "nixpkgs-update",
         "nixpkgs-update-github-releases": "nixpkgs-update-github-releases",
         "nur-update": "nur-update",

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,8 @@
 
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+
+    nixpkgs-darwin-pinned.url = "github:NixOS/nixpkgs/2dbc8f62d8af7a1ab962e4b20d12b25ddcb86ced";
   };
 
   outputs = inputs @ { flake-parts, self, ... }:
@@ -98,7 +100,8 @@
           in
           {
             darwin01 = darwinSystem {
-              pkgs = inputs.nixpkgs.legacyPackages.aarch64-darwin;
+              # https://github.com/nix-community/infra/issues/1155
+              pkgs = inputs.nixpkgs-darwin-pinned.legacyPackages.aarch64-darwin;
               modules = [ ./hosts/darwin01/configuration.nix ];
             };
             darwin02 = darwinSystem {
@@ -106,7 +109,8 @@
               modules = [ ./hosts/darwin02/configuration.nix ];
             };
             darwin03 = darwinSystem {
-              pkgs = inputs.nixpkgs.legacyPackages.aarch64-darwin;
+              # use the same nixpkgs as darwin01
+              pkgs = inputs.nixpkgs-darwin-pinned.legacyPackages.aarch64-darwin;
               modules = [ ./hosts/darwin03/configuration.nix ];
             };
           };


### PR DESCRIPTION
https://github.com/nix-community/infra/issues/1155

Encountered an unexpected macos security issue that blocked access to a new versions of bash, nix and caused the last deployment to fail. Pinning nixpkgs for now while I figure out a proper fix.