### PR TITLE
.github/workflows/darwin.yml: add timeout

### DIFF
--- a/.github/workflows/darwin.yml
+++ b/.github/workflows/darwin.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         host: [darwin01, darwin02, darwin03]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix


### PR DESCRIPTION
add a 15 minute timeout so if the deployment gets stuck it doesn't run until the default 6 hour timeout