### PR TITLE
modules/nixos/monitoring: ofborg: telegraf -> prometheus

### DIFF
--- a/modules/nixos/monitoring/prometheus.nix
+++ b/modules/nixos/monitoring/prometheus.nix
@@ -25,6 +25,17 @@
             }
           ];
       }
+      {
+        job_name = "ofborg";
+        scrape_interval = "60s";
+        metrics_path = "/prometheus.php";
+        scheme = "https";
+        static_configs = [
+          {
+            targets = [ "events.ofborg.org" ];
+          }
+        ];
+      }
     ];
     alertmanagers = [
       {

--- a/modules/nixos/monitoring/telegraf.nix
+++ b/modules/nixos/monitoring/telegraf.nix
@@ -41,8 +41,5 @@
           timeout = "10s";
         })
         hosts;
-    prometheus.urls = [
-      "https://events.ofborg.org/prometheus.php"
-    ];
   };
 }


### PR DESCRIPTION
scraping this target with telegraf isn't working since 1.30.0