### PR TITLE
darwin/community-builder: add user annalee

### DIFF
--- a/modules/darwin/community-builder/keys/annalee
+++ b/modules/darwin/community-builder/keys/annalee
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICYVa+LgUej5gFSu2g8oWqzn4Tr0sRqRg8xcYBm0mHi2 anna@chatterbox

--- a/modules/darwin/community-builder/users.nix
+++ b/modules/darwin/community-builder/users.nix
@@ -177,6 +177,11 @@ let
       trusted = true;
       uid = 557;
     }
+    {
+      name = "annalee";
+      trusted = true;
+      uid = 558;
+    }
   ];
 in
 {


### PR DESCRIPTION
I'm working on some changes to update darwin bootstrap and being able to test on aarch64 would be helpful.

performing bootstrap builds takes a long time on my hackintosh x64 VM. 6-12 hours so if there is not ample capacity on the machines having access probably won't help.

bootstrap prs:
- https://github.com/NixOS/nixpkgs/pull/295558
- https://github.com/NixOS/nixpkgs/pull/295557

old merge: fixing libcxxabi on clang issues.
- https://github.com/NixOS/nixpkgs/pull/292043

all nixpkgs PRs.
https://github.com/NixOS/nixpkgs/pulls/a-n-n-a-l-e-e