### PR TITLE
build02/nixpkgs-update: update github fetcher 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,16 +144,16 @@
     "nixpkgs-update-github-releases": {
       "flake": false,
       "locked": {
-        "lastModified": 1697923309,
-        "narHash": "sha256-XCIw5XsV3q2BEE5q+NIokBIKz1TzfsAbSESffB0eGHA=",
-        "owner": "rhendric",
+        "lastModified": 1710739204,
+        "narHash": "sha256-PKZNV6ITH6n7LrFtqg7bJNLZxn31IlqCVkEm5tjdjFE=",
+        "owner": "qowoz",
         "repo": "nixpkgs-update-github-releases",
-        "rev": "cbdc6775eab07c44d94d50e7b714c3ca83c02219",
+        "rev": "490849230ae8044bb024de2f31d2bc724157e7e1",
         "type": "github"
       },
       "original": {
-        "owner": "rhendric",
-        "ref": "rhendric/misc-patches",
+        "owner": "qowoz",
+        "ref": "patches",
         "repo": "nixpkgs-update-github-releases",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
     nixpkgs-update.url = "github:qowoz/nixpkgs-update/patches";
     nixpkgs-update.inputs.runtimeDeps.follows = "nixpkgs";
     nixpkgs-update.inputs.mmdoc.follows = "";
-    nixpkgs-update-github-releases.url = "github:rhendric/nixpkgs-update-github-releases/rhendric/misc-patches";
+    nixpkgs-update-github-releases.url = "github:qowoz/nixpkgs-update-github-releases/patches";
     nixpkgs-update-github-releases.flake = false;
 
     buildbot-nix.url = "github:Mic92/buildbot-nix";

--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -107,12 +107,15 @@ let
   mkFetcher = name: cmd: {
     after = [ "network-online.target" ];
     wants = [ "network-online.target" ];
-    path = nixpkgsUpdateSystemDependencies;
+    path = nixpkgsUpdateSystemDependencies ++ [
+      # nixpkgs-update-github-releases
+      (pkgs.python3.withPackages (p: with p;
+      [ requests dateutil libversion cachecontrol lockfile filelock ]
+      ))
+    ];
     # API_TOKEN is used by nixpkgs-update-github-releases
     # using a token from another account so the rate limit doesn't block opening PRs
     environment.API_TOKEN_FILE = "/var/lib/nixpkgs-update/github_token_with_username.txt";
-    # Used by nixpkgs-update-github-releases to install python dependencies
-    environment.NIX_PATH = "nixpkgs=/var/cache/nixpkgs-update/fetcher/nixpkgs";
     environment.XDG_CACHE_HOME = "/var/cache/nixpkgs-update/fetcher/";
 
     serviceConfig = {


### PR DESCRIPTION
Easier to manage these deps in tree than using a nixpkgs checkout on the host.

cc @ryantm 