### PR TITLE
build02/nixpkgs-update/gitconfig: use ssh for push

### DIFF
--- a/hosts/build02/gitconfig.txt
+++ b/hosts/build02/gitconfig.txt
@@ -1,3 +1,6 @@
 [user]
         email = ryantm-bot@ryantm.com
         name = R. Ryantm
+
+[url "git@github.com:"]
+        pushInsteadOf = https://github.com/


### PR DESCRIPTION
`nixpkgs-update` sets https by default but we use ssh.