### PR TITLE
build02/nixpkgs-update: reduce workers to four

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -191,8 +191,6 @@ in
   systemd.services.nixpkgs-update-worker2 = mkWorker "worker2";
   systemd.services.nixpkgs-update-worker3 = mkWorker "worker3";
   systemd.services.nixpkgs-update-worker4 = mkWorker "worker4";
-  systemd.services.nixpkgs-update-worker5 = mkWorker "worker5";
-  systemd.services.nixpkgs-update-worker6 = mkWorker "worker6";
   # Too many workers cause out-of-memory.
 
   systemd.services.nixpkgs-update-supervisor = {


### PR DESCRIPTION
Want to try this for a couple of weeks to see if it helps with some of the nixpkgs-review timeouts and if it can maintain the current pace of updates (currently seems to cycle through everything in a few days.)