### PR TITLE
Revert "modules/nixos/monitoring: ofborg: telegraf -> prometheus"

### DIFF
--- a/modules/nixos/monitoring/prometheus.nix
+++ b/modules/nixos/monitoring/prometheus.nix
@@ -25,17 +25,6 @@
             }
           ];
       }
-      {
-        job_name = "ofborg";
-        scrape_interval = "60s";
-        metrics_path = "/prometheus.php";
-        scheme = "https";
-        static_configs = [
-          {
-            targets = [ "events.ofborg.org" ];
-          }
-        ];
-      }
     ];
     alertmanagers = [
       {

--- a/modules/nixos/monitoring/telegraf.nix
+++ b/modules/nixos/monitoring/telegraf.nix
@@ -41,5 +41,8 @@
           timeout = "10s";
         })
         hosts;
+    prometheus.urls = [
+      "https://events.ofborg.org/prometheus.php"
+    ];
   };
 }


### PR DESCRIPTION
This seems to have been fixed upstream, should be in the next release.

https://nixpk.gs/pr-tracker.html?pr=300851