### PR TITLE
nixos/community-builder: add binarycat-untrusted user

### DIFF
--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -25,6 +25,11 @@ let
       keys = ./keys/binarycat;
     };
 
+    binarycat-untrusted = {
+      trusted = false;
+      keys = ./keys/binarycat;
+    };
+
     bobby285271 = {
       trusted = true;
       keys = ./keys/bobby285271;


### PR DESCRIPTION
i want to do some testing related to untrusted users and distributed builds, and in order to do that i need access to an untrusted user.