### PR TITLE
modules/nixos/common/comin: add prometheus, build04: switch to comin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712514836,
-        "narHash": "sha256-fXh5xZkpOZjcDpYdq1lB8O+aKogfVuRr/iwtkXQvp2Y=",
+        "lastModified": 1712611219,
+        "narHash": "sha256-RYCOkK8Qg9Fb35S/xWEpEGqraTal+VoIugy8wi/Q52I=",
         "owner": "nlewo",
         "repo": "comin",
-        "rev": "c7cf7b064f1b5904c834922c508a258944b48b21",
+        "rev": "147eef7be66b7b03b2733a9a9a9bd07225ac319e",
         "type": "github"
       },
       "original": {

--- a/hosts/build04/configuration.nix
+++ b/hosts/build04/configuration.nix
@@ -9,6 +9,9 @@
     inputs.self.nixosModules.remote-builder
   ];
 
+  services.comin.enable = true;
+  system.autoUpgrade.enable = false;
+
   nixCommunity.remote-builder.key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEmdo1x1QkRepZf7nSe+OdEWX+wOjkBLF70vX9F+xf68 builder";
 
   networking.hostName = "build04";

--- a/modules/nixos/common/comin.nix
+++ b/modules/nixos/common/comin.nix
@@ -4,6 +4,10 @@
     inputs.comin.nixosModules.comin
   ];
 
+  services.telegraf.extraConfig.inputs.prometheus.urls = [
+    "http://localhost:4243/metrics"
+  ];
+
   services.telegraf.extraConfig.inputs.http = {
     urls = [ "http://localhost:4242/status" ];
     data_format = "json";


### PR DESCRIPTION
Will try this for another week or so on two hosts with the prometheus metrics and then look at dropping autoupgrade.