### PR TITLE
darwin/community-builder: add user gador

### DIFF
--- a/modules/darwin/community-builder/keys/gador
+++ b/modules/darwin/community-builder/keys/gador
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMm/OTWImM6tMUu5JVA+xf9Vn33yaidq5KMHgij0gm5b gador@darwin-build-box

--- a/modules/darwin/community-builder/users.nix
+++ b/modules/darwin/community-builder/users.nix
@@ -193,6 +193,11 @@ let
       trusted = true;
       uid = 560;
     }
+    {
+      name = "gador";
+      trusted = true;
+      uid = 561;
+    }
   ];
 in
 {


### PR DESCRIPTION
I'd like to work on some darwin packages but only have access to an `aarch64-darwin` builder at home. 

I did some work on nixpkgs for the past two years:

[194 authored prs](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+author%3Agador+sort%3Aupdated-desc+is%3Amerged+)
[77 reviews packages](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+reviewed-by%3Agador+-author%3Agador+)
[Maintainer of 45 pacakges](https://repology.org/projects/?search=&maintainer=florian.brandes%40posteo.de&category=&inrepo=nix_unstable&notinrepo=&repos=&families=&repos_newest=&families_newest=)

and would like to build, debug and test for `x86_64-darwin`, too. 