### PR TITLE
build02/nixpkgs-update: delete old logs daily, run backup after delete

### DIFF
--- a/hosts/build02/nixpkgs-update-backup.nix
+++ b/hosts/build02/nixpkgs-update-backup.nix
@@ -4,9 +4,12 @@
 
   sops.secrets.hetzner-borgbackup-ssh = { };
 
-  systemd.services.borgbackup-job-nixpkgs-update.serviceConfig.ReadWritePaths = [
-    "/var/log/telegraf"
-  ];
+  systemd.services.borgbackup-job-nixpkgs-update = {
+    after = [ "nixpkgs-update-delete-old-logs.service" ];
+    serviceConfig.ReadWritePaths = [
+      "/var/log/telegraf"
+    ];
+  };
 
   services.borgbackup.jobs.nixpkgs-update = {
     paths = [

--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -225,7 +225,7 @@ in
   };
 
   systemd.services.nixpkgs-update-delete-old-logs = {
-    startAt = "weekly";
+    startAt = "daily";
     # delete logs older than 18 months, delete worker logs older than 3 months, delete empty directories
     script = ''
       ${pkgs.findutils}/bin/find /var/log/nixpkgs-update -type f -mtime +548 -delete


### PR DESCRIPTION
Not sure why these two services have started conflicting recently when they hadn't previously been a problem.