### PR TITLE
Revert "modules/nixos/buildbot: add `Upholds`"

### DIFF
--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -63,11 +63,6 @@
     ];
   };
 
-  systemd.targets.multi-user.unitConfig.Upholds = [
-    "buildbot-master.service"
-    "buildbot-worker.service"
-  ];
-
   sops.secrets.buildbot-nix-worker-password = { };
 
   services.buildbot-nix.worker = {


### PR DESCRIPTION
This reverts commit 83f3142fd8d08169d0fab4d4a4f83bc603287371.

Seems using this to restart buildbot wasn't a good idea as buildbot may have an actual error.