### PR TITLE
build02: set zfs_arc_max

### DIFF
--- a/hosts/build02/configuration.nix
+++ b/hosts/build02/configuration.nix
@@ -11,6 +11,8 @@
     inputs.self.nixosModules.disko-zfs
   ];
 
+  boot.kernelParams = [ "zfs.zfs_arc_max=17179869184" ]; # 16GB, try to limit OOM kills / reboots
+
   networking.hostName = "build02";
   networking.nameservers = [ "1.1.1.1" "1.0.0.1" ];
 


### PR DESCRIPTION
By default it can use up to 64GB (50%) so limiting it to 16GB seems like it might help?

___

<img width="400" alt="zfs" src="https://github.com/nix-community/infra/assets/59103226/bb0dcab8-2b2e-41e3-a0fd-3548edb54635">

