### PR TITLE
modules/darwin/common: add mdutil to postActivation script

### DIFF
--- a/modules/darwin/common/default.nix
+++ b/modules/darwin/common/default.nix
@@ -70,6 +70,9 @@
     echo disabling netbios... >&2
     launchctl disable system/netbiosd
     launchctl unload -w /System/Library/LaunchDaemons/com.apple.netbiosd.plist 2>/dev/null || true
+    echo disabling spotlight indexing... >&2
+    mdutil -a -i off -d &> /dev/null
+    mdutil -a -E &> /dev/null
   '';
 
   time.timeZone = "GMT";


### PR DESCRIPTION
Each time we've set up a new darwin machine I've run these manually and then forgotten to add them here.