### PR TITLE
build02/nixpkgs-update: remove extra github_token symlink

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -243,7 +243,6 @@ in
 
     "d /var/lib/nixpkgs-update/bin/ 700 r-ryantm r-ryantm - -"
     "L+ ${nixpkgs-update-bin} - - - - ${inputs.nixpkgs-update.packages.${pkgs.system}.default}/bin/nixpkgs-update"
-    "L+ /var/lib/nixpkgs-update/worker/github_token.txt - - - - ${config.sops.secrets.github-r-ryantm-token.path}"
   ];
 
   sops.secrets.github-r-ryantm-key = {
@@ -253,7 +252,7 @@ in
   };
 
   sops.secrets.github-r-ryantm-token = {
-    path = "/var/lib/nixpkgs-update/github_token.txt";
+    path = "/var/lib/nixpkgs-update/worker/github_token.txt";
     owner = "r-ryantm";
     group = "r-ryantm";
   };


### PR DESCRIPTION
cc @ryantm @rhendric

I've tested the change in this PR and it seems to be fine. The workers can access the github API (to open PRs and check for open PRs) and the delete-done service for merged PRs branches also works.

The `/var/lib/nixpkgs-update/worker/github_token.txt` symlink was added in https://github.com/nix-community/infra/commit/37b2fbef9070024aad43ce1535dcb8644087c96f as part of the change to the worker model.

After the initial change this code was touched in https://github.com/nix-community/infra/commit/8918a47f7e0cd88c359977d507e2bf59039c756d, https://github.com/nix-community/infra/commit/6843ef7472b9d1ef6d2faee00403d39d5c0bfabe, https://github.com/nix-community/infra/commit/399db233f24edcea64979adc82e22a5ab80c4fe8.