### PR TITLE
modules/nixos/monitoring/alert-rules: increase comin commit alert to 90m

### DIFF
--- a/modules/nixos/monitoring/alert-rules.nix
+++ b/modules/nixos/monitoring/alert-rules.nix
@@ -13,7 +13,7 @@
       {
         CominDeploymentDifferentCommits = {
           expr = ''count(count by (commit_id) (comin_deployment_info)) > 1'';
-          for = "30m";
+          for = "90m";
           annotations.description = "One or more comin deployments are on different commits";
         };
 


### PR DESCRIPTION
seems 30m isn't quite long enough for the gandi vm, I'll bump this to 90m so it'll only fire if there is an actual issue.