### PR TITLE
modules/nixos/buildbot: set Restart, RestartSec

### DIFF
--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -14,6 +14,15 @@
     "http://localhost:8011/metrics"
   ];
 
+  systemd.services.buildbot-master.serviceConfig = {
+    Restart = "on-failure";
+    RestartSec = "30s";
+  };
+  systemd.services.buildbot-worker.serviceConfig = {
+    Restart = "on-failure";
+    RestartSec = "30s";
+  };
+
   sops.secrets.buildbot-github-oauth-secret = { };
   sops.secrets.buildbot-github-token = { };
   sops.secrets.buildbot-github-webhook-secret = { };


### PR DESCRIPTION
Buildbot fails if it can't connect to github after the host is rebooted.

alternative to 83f3142fd8d08169d0fab4d4a4f83bc603287371