### PR TITLE
serve logs on nixpkgs-update-logs.nix-community.org

### DIFF
--- a/docs/update-bot.md
+++ b/docs/update-bot.md
@@ -1,6 +1,6 @@
 - Config: [https://github.com/nix-community/infra/tree/master/hosts/build02](https://github.com/nix-community/infra/tree/master/hosts/build02)
 - Docs: [https://nix-community.github.io/nixpkgs-update](https://nix-community.github.io/nixpkgs-update)
-- Logs: [https://r.ryantm.com/log/](https://r.ryantm.com/log/)
+- Logs: [https://nixpkgs-update-logs.nix-community.org](https://nixpkgs-update-logs.nix-community.org)
 - Nixpkgs Pull Requests: [https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+author%3Ar-ryantm](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+author%3Ar-ryantm)
 - Matrix: [https://matrix.to/#/#nixpkgs-update:nixos.org](https://matrix.to/#/#nixpkgs-update:nixos.org)
 - Source: [https://github.com/nix-community/nixpkgs-update](https://github.com/nix-community/nixpkgs-update)

--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -49,7 +49,7 @@ let
 
     script = ''
       mkdir -p "$LOGS_DIRECTORY/~workers/"
-      # This is for public logs at https://r.ryantm.com/log/~workers
+      # This is for public logs at nixpkgs-update-logs.nix-community.org/~workers
       exec  > >(rotatelogs -eD "$LOGS_DIRECTORY"'/~workers/%Y-%m-%d-${name}.stdout.log' 86400)
       exec 2> >(rotatelogs -eD "$LOGS_DIRECTORY"'/~workers/%Y-%m-%d-${name}.stderr.log' 86400 >&2)
 
@@ -216,10 +216,10 @@ in
 
     script = ''
       mkdir -p "$LOGS_DIRECTORY/~supervisor"
-      # This is for public logs at https://r.ryantm.com/log/~supervisor
+      # This is for public logs at nixpkgs-update-logs.nix-community.org/~supervisor
       exec  > >(rotatelogs -eD "$LOGS_DIRECTORY"'/~supervisor/%Y-%m-%d.stdout.log' 86400)
       exec 2> >(rotatelogs -eD "$LOGS_DIRECTORY"'/~supervisor/%Y-%m-%d.stderr.log' 86400 >&2)
-      # Fetcher output is hosted at https://r.ryantm.com/log/~fetchers
+      # Fetcher output is hosted at nixpkgs-update-logs.nix-community.org/~fetchers
       python3 ${./supervisor.py} "$LOGS_DIRECTORY/~supervisor/state.db" "$LOGS_DIRECTORY/~fetchers" "$RUNTIME_DIRECTORY/work.sock"
     '';
   };
@@ -269,6 +269,19 @@ in
     group = "r-ryantm";
   };
 
+  services.nginx.virtualHosts."nixpkgs-update-logs.nix-community.org" = {
+    forceSSL = true;
+    enableACME = true;
+    locations."/" = {
+      alias = "/var/log/nixpkgs-update/";
+      extraConfig = ''
+        charset utf-8;
+        autoindex on;
+      '';
+    };
+  };
+
+  # TODO: permanent redirect r.ryantm.com/log/ -> nixpkgs-update-logs.nix-community.org
   services.nginx.virtualHosts."r.ryantm.com" = {
     forceSSL = true;
     enableACME = true;

--- a/modules/nixos/monitoring/telegraf.nix
+++ b/modules/nixos/monitoring/telegraf.nix
@@ -20,7 +20,7 @@
         tags.org = "nix-community";
       }
       {
-        urls = [ "https://r.ryantm.com/log/~supervisor/" ];
+        urls = [ "https://nixpkgs-update-logs.nix-community.org/~supervisor/" ];
         response_string_match = "state.db";
         tags.host = "build02.nix-community.org";
         tags.org = "nix-community";

--- a/terraform/cloudflare_nix-community_org.tf
+++ b/terraform/cloudflare_nix-community_org.tf
@@ -145,6 +145,13 @@ resource "cloudflare_record" "nix-community-org-darwin-build-box-CNAME" {
   type    = "CNAME"
 }
 
+resource "cloudflare_record" "nix-community-org-nixpkgs-update-logs-CNAME" {
+  zone_id = local.nix_community_zone_id
+  name    = "nixpkgs-update-logs"
+  value   = "build02.nix-community.org"
+  type    = "CNAME"
+}
+
 resource "cloudflare_record" "nix-community-org-buildbot-CNAME" {
   zone_id = local.nix_community_zone_id
   name    = "buildbot"


### PR DESCRIPTION
@nix-community/admin Are we okay with the logs on their own subdomain? Simpler for future redirects if nixpkgs-update does move to the nixos org.