### PR TITLE
build02: bump zfs_arc_max to 24GB, build02/nixpkgs-update: add another worker

### DIFF
--- a/hosts/build02/configuration.nix
+++ b/hosts/build02/configuration.nix
@@ -11,7 +11,7 @@
     inputs.self.nixosModules.disko-zfs
   ];
 
-  boot.kernelParams = [ "zfs.zfs_arc_max=17179869184" ]; # 16GB, try to limit OOM kills / reboots
+  boot.kernelParams = [ "zfs.zfs_arc_max=${toString (24 * 1024 * 1024 * 1024)}" ]; # 24GB, try to limit OOM kills / reboots
 
   networking.hostName = "build02";
   networking.nameservers = [ "1.1.1.1" "1.0.0.1" ];

--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -189,6 +189,7 @@ in
   systemd.services.nixpkgs-update-worker2 = mkWorker "worker2";
   systemd.services.nixpkgs-update-worker3 = mkWorker "worker3";
   systemd.services.nixpkgs-update-worker4 = mkWorker "worker4";
+  systemd.services.nixpkgs-update-worker5 = mkWorker "worker5";
   # Too many workers cause out-of-memory.
 
   systemd.services.nixpkgs-update-supervisor = {


### PR DESCRIPTION
The bot seems to be falling behind a little now with just four workers so adding another one back. 

Also going to try giving zfs a little bit more memory as recently we haven't had any crashes and only a couple of OOMs.