### PR TITLE
Revert "modules/darwin/hercules-ci: add security to service path"

### DIFF
--- a/modules/darwin/hercules-ci/default.nix
+++ b/modules/darwin/hercules-ci/default.nix
@@ -1,9 +1,4 @@
-{ config, pkgs, ... }:
-let
-  securityWrapper = pkgs.writeScriptBin "security" ''
-    exec /usr/bin/security "$@"
-  '';
-in
+{ config, ... }:
 {
   age.secrets.binary-caches = {
     file = ../../../secrets/binary-caches.age;
@@ -25,8 +20,4 @@ in
     binaryCachesPath = config.age.secrets.binary-caches.path;
     clusterJoinTokenPath = config.age.secrets.cluster-join-token.path;
   };
-
-  # hercules-ci-agent: security: createProcess: posix_spawnp: does not exist
-  # https://github.com/LnL7/nix-darwin/blob/36524adc31566655f2f4d55ad6b875fb5c1a4083/modules/services/hercules-ci-agent/default.nix#L28
-  launchd.daemons.hercules-ci-agent.path = pkgs.lib.mkForce [ config.nix.package securityWrapper ];
 }


### PR DESCRIPTION
This reverts commit 5da85a9b7276f15a64052dcc820ab210d742b914.

Fixed in nix-darwin by https://github.com/LnL7/nix-darwin/commit/251eaabfa0f421a864e75e6b1a23c2c73e7bc332