### PR TITLE
darwin & linux community builder: add a sane zsh config

### DIFF
--- a/modules/darwin/community-builder/default.nix
+++ b/modules/darwin/community-builder/default.nix
@@ -1,6 +1,16 @@
+{ pkgs, ... }:
 {
   imports = [
     ./packages.nix
     ./users.nix
   ];
+
+  programs.zsh = {
+    # https://grml.org/zsh/grmlzshrc.html
+    # https://grml.org/zsh/grml-zsh-refcard.pdf
+    interactiveShellInit = ''
+      source ${pkgs.grml-zsh-config}/etc/zsh/zshrc
+    '';
+    promptInit = ""; # otherwise it'll override the grml prompt
+  };
 }

--- a/modules/nixos/community-builder/default.nix
+++ b/modules/nixos/community-builder/default.nix
@@ -8,5 +8,13 @@
   # disable generated completion
   environment.etc."fish/generated_completions".text = pkgs.lib.mkForce "";
 
-  programs.zsh.enable = true;
+  programs.zsh = {
+    enable = true;
+    # https://grml.org/zsh/grmlzshrc.html
+    # https://grml.org/zsh/grml-zsh-refcard.pdf
+    interactiveShellInit = ''
+      source ${pkgs.grml-zsh-config}/etc/zsh/zshrc
+    '';
+    promptInit = ""; # otherwise it'll override the grml prompt
+  };
 }


### PR DESCRIPTION
Biggest benefits are better prompt and the ability to properly use arrow up
to go through the history

`nix<up>` searches through commands which start with `nix`

https://grml.org/


I like using this as the the default configuration on all my machines