### PR TITLE
Revert "modules/darwin/hercules-ci: add sandbox workaround"

### DIFF
--- a/modules/darwin/hercules-ci/default.nix
+++ b/modules/darwin/hercules-ci/default.nix
@@ -20,8 +20,4 @@
     binaryCachesPath = config.age.secrets.binary-caches.path;
     clusterJoinTokenPath = config.age.secrets.cluster-join-token.path;
   };
-
-  system.systemBuilderArgs.sandboxProfile = ''
-    (allow file-read* file-write* process-exec mach-lookup (subpath "${builtins.storeDir}"))
-  '';
 }


### PR DESCRIPTION
This reverts commit 1f6af7ef7557dc4c4853021fb4664a886e4b2701.