### PR TITLE
flake: nixpkgs-update: follow nixpkgs for runtime deps

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -189,7 +189,9 @@
           "empty"
         ],
         "nixpkgs": "nixpkgs_2",
-        "runtimeDeps": "runtimeDeps",
+        "runtimeDeps": [
+          "nixpkgs"
+        ],
         "treefmt-nix": [
           "treefmt-nix"
         ]
@@ -276,22 +278,6 @@
         "srvos": "srvos",
         "systems": "systems",
         "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "runtimeDeps": {
-      "locked": {
-        "lastModified": 1714247354,
-        "narHash": "sha256-6dFKqP/aCKIdpOgqgIQUrRT0NOfVc14ftNcdELa4Pu4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c8d7c8a78fb516c0842cc65346506a565c88014d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable-small",
-        "repo": "nixpkgs",
-        "type": "github"
       }
     },
     "sops-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
     nixpkgs-update-github-releases.flake = false;
     nixpkgs-update-github-releases.url = "github:nix-community/nixpkgs-update-github-releases";
     nixpkgs-update.inputs.mmdoc.follows = "empty";
+    nixpkgs-update.inputs.runtimeDeps.follows = "nixpkgs";
     nixpkgs-update.inputs.treefmt-nix.follows = "treefmt-nix";
     nixpkgs-update.url = "github:nix-community/nixpkgs-update";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";


### PR DESCRIPTION
Eventually I'll finish fixing the haskell breakage in https://github.com/nix-community/nixpkgs-update/pull/419 but for now I'll go back to following nixpkgs for these deps.