### PR TITLE
use zpool workaround by default

### DIFF
--- a/hosts/build01/configuration.nix
+++ b/hosts/build01/configuration.nix
@@ -1,4 +1,4 @@
-{ config, inputs, ... }:
+{ inputs, ... }:
 {
   imports = [
     inputs.srvos.nixosModules.hardware-hetzner-online-amd
@@ -7,9 +7,6 @@
     inputs.self.nixosModules.builder
     inputs.self.nixosModules.community-builder
   ];
-
-  # the default zpool import services somehow times out while this import works fine?
-  boot.initrd.systemd.services.zfs-import-zroot.serviceConfig.ExecStartPre = "${config.boot.zfs.package}/bin/zpool import -N -f zroot";
 
   nixCommunity.gc.gbFree = 500;
 

--- a/hosts/build02/configuration.nix
+++ b/hosts/build02/configuration.nix
@@ -1,4 +1,4 @@
-{ config, inputs, ... }:
+{ inputs, ... }:
 
 {
   imports = [
@@ -14,9 +14,6 @@
 
   # set in srvos, remove when reinstalling
   networking.hostId = "deadbeef";
-
-  # the default zpool import services somehow times out while this import works fine?
-  boot.initrd.systemd.services.zfs-import-zroot.serviceConfig.ExecStartPre = "${config.boot.zfs.package}/bin/zpool import -N -f zroot";
 
   nixCommunity.gc.gbFree = 500;
 

--- a/hosts/build03/configuration.nix
+++ b/hosts/build03/configuration.nix
@@ -1,4 +1,4 @@
-{ config, inputs, ... }:
+{ inputs, ... }:
 {
   imports = [
     inputs.srvos.nixosModules.mixins-nginx
@@ -16,9 +16,6 @@
     inputs.self.nixosModules.nur-update
     ./postgresql.nix
   ];
-
-  # the default zpool import services somehow times out while this import works fine?
-  boot.initrd.systemd.services.zfs-import-zroot.serviceConfig.ExecStartPre = "${config.boot.zfs.package}/bin/zpool import -N -f zroot";
 
   nixCommunity.gc.gbFree = 500;
 

--- a/modules/nixos/disko-zfs.nix
+++ b/modules/nixos/disko-zfs.nix
@@ -1,4 +1,4 @@
-{ inputs, ... }:
+{ config, inputs, ... }:
 {
   imports = [ inputs.disko.nixosModules.disko ];
 
@@ -8,6 +8,9 @@
     efiSupport = true;
     efiInstallAsRemovable = true;
   };
+
+  # the default zpool import services somehow times out while this import works fine?
+  boot.initrd.systemd.services.zfs-import-zroot.serviceConfig.ExecStartPre = "${config.boot.zfs.package}/bin/zpool import -N -f zroot";
 
   # Sometimes fails after the first try, with duplicate pool name errors
   boot.initrd.systemd.services.zfs-import-zroot.serviceConfig.Restart = "on-failure";


### PR DESCRIPTION
I think this is okay to use by default? Only host that isn't currently using it is build04.