### PR TITLE
modules/nixos/common: disable scheduled optimise

### DIFF
--- a/modules/nixos/common/default.nix
+++ b/modules/nixos/common/default.nix
@@ -19,6 +19,10 @@
     inputs.srvos.nixosModules.server
   ];
 
+  # Hard-link duplicated files
+  nix.settings.auto-optimise-store = true;
+  nix.optimise.automatic = false;
+
   # users in trusted group are trusted by the nix-daemon
   nix.settings.trusted-users = [ "@trusted" ];
 

--- a/modules/shared/nix-daemon.nix
+++ b/modules/shared/nix-daemon.nix
@@ -11,9 +11,6 @@ in
 
     settings.substituters = [ "https://nix-community.cachix.org" ];
 
-    # Hard-link duplicated files
-    settings.auto-optimise-store = pkgs.lib.mkDefault true;
-
     # auto-free the /nix/store
     settings.min-free = asGB 10;
     settings.max-free = asGB 50;


### PR DESCRIPTION
Not sure that optimising the entire store on a schedule is better than `auto-optimise-store` on most full multi TB disks so just disable it for now and keep the status quo.