### PR TITLE
modules/nixos/monitoring/prometheus: increase repeat_interval to 12h

### DIFF
--- a/modules/nixos/monitoring/prometheus.nix
+++ b/modules/nixos/monitoring/prometheus.nix
@@ -53,7 +53,7 @@
             group_by = [ "host" ];
             group_wait = "5m";
             group_interval = "5m";
-            repeat_interval = "4h";
+            repeat_interval = "12h";
             receiver = "nix-community";
           }
         ];


### PR DESCRIPTION
Every 4 hours is a bit spammy.