### PR TITLE
darwin/community-builder: add user sebtm

### DIFF
--- a/modules/darwin/community-builder/keys/sebtm
+++ b/modules/darwin/community-builder/keys/sebtm
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICk8HA/hrBTY/LeXV6gARww046iR9AAq83xk75VC3Z/0 mail@sebastian-sellmeier.de

--- a/modules/darwin/community-builder/users.nix
+++ b/modules/darwin/community-builder/users.nix
@@ -291,6 +291,13 @@ let
       uid = 547;
       keys = ./keys/linj;
     }
+    {
+      # lib.maintainers.sebtm, https://github.com/sebtm
+      name = "sebtm";
+      trusted = true;
+      uid = 548;
+      keys = ./keys/sebtm;
+    }
   ];
 in
 {


### PR DESCRIPTION
I'm nixpkgs/home-manager maintainer, recently trying to use/help out with https://github.com/tstat/raspberry-pi-nix and attempts to build/improve NixOS on the BPI-R3 why I would like to request access to the shared aarch64-builder. Also I maintain a few packages, some of them build and work on darwin and I have no building possibility.