### PR TITLE
flake: add lite-config

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,6 +147,21 @@
         "type": "github"
       }
     },
+    "lite-config": {
+      "locked": {
+        "lastModified": 1723691425,
+        "narHash": "sha256-xOroQo/+CAtocvJQsGPE5ukr1Btp72xlcWPB4tBZp6M=",
+        "owner": "yelite",
+        "repo": "lite-config",
+        "rev": "34357ad12ad0a66b2de55a2457159bda36c71a06",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yelite",
+        "repo": "lite-config",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -269,6 +284,7 @@
         "empty": "empty",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
+        "lite-config": "lite-config",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
         "nixpkgs-update": "nixpkgs-update",

--- a/hosts/build01/default.nix
+++ b/hosts/build01/default.nix
@@ -2,7 +2,6 @@
 {
   imports = [
     inputs.srvos.nixosModules.hardware-hetzner-online-amd
-    inputs.self.nixosModules.common
     inputs.self.nixosModules.disko-zfs
     inputs.self.nixosModules.builder
     inputs.self.nixosModules.community-builder
@@ -12,8 +11,6 @@
 
   # Emulate riscv64 until we have proper builders
   boot.binfmt.emulatedSystems = [ "riscv64-linux" ];
-
-  networking.hostName = "build01";
 
   systemd.network.networks."10-uplink".networkConfig.Address = "2a01:4f9:3b:2946::1/64";
 

--- a/hosts/build02/default.nix
+++ b/hosts/build02/default.nix
@@ -6,7 +6,6 @@
     inputs.srvos.nixosModules.hardware-hetzner-online-amd
     ./nixpkgs-update.nix
     ./nixpkgs-update-backup.nix
-    inputs.self.nixosModules.common
     inputs.self.nixosModules.builder
     inputs.self.nixosModules.disko-zfs
   ];
@@ -18,7 +17,6 @@
 
   boot.kernelParams = [ "zfs.zfs_arc_max=${toString (24 * 1024 * 1024 * 1024)}" ]; # 24GB, try to limit OOM kills / reboots
 
-  networking.hostName = "build02";
   networking.nameservers = [
     "1.1.1.1"
     "1.0.0.1"

--- a/hosts/build03/default.nix
+++ b/hosts/build03/default.nix
@@ -3,7 +3,6 @@
   imports = [
     inputs.srvos.nixosModules.mixins-nginx
     inputs.srvos.nixosModules.hardware-hetzner-online-amd
-    inputs.self.nixosModules.common
     inputs.self.nixosModules.disko-zfs
     inputs.self.nixosModules.buildbot
     inputs.self.nixosModules.builder
@@ -20,8 +19,6 @@
   nixCommunity.gc.gbFree = 500;
 
   systemd.network.networks."10-uplink".networkConfig.Address = "2a01:4f8:2190:2698::2";
-
-  networking.hostName = "build03";
 
   system.stateVersion = "23.11";
 }

--- a/hosts/build04/default.nix
+++ b/hosts/build04/default.nix
@@ -3,7 +3,6 @@
   imports = [
     inputs.srvos.nixosModules.hardware-hetzner-online-arm
     inputs.self.nixosModules.disko-zfs
-    inputs.self.nixosModules.common
     inputs.self.nixosModules.builder
     inputs.self.nixosModules.hercules-ci
     inputs.self.nixosModules.remote-builder
@@ -17,8 +16,6 @@
   networking.hostId = "deadbeef";
 
   nixCommunity.remote-builder.key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEmdo1x1QkRepZf7nSe+OdEWX+wOjkBLF70vX9F+xf68 builder";
-
-  networking.hostName = "build04";
 
   system.stateVersion = "23.11";
 

--- a/hosts/darwin01/default.nix
+++ b/hosts/darwin01/default.nix
@@ -2,7 +2,6 @@
 
 {
   imports = [
-    inputs.self.darwinModules.common
     inputs.self.darwinModules.builder
     inputs.self.darwinModules.community-builder
   ];
@@ -14,8 +13,6 @@
 
   # disable nixos-tests
   nix.settings.system-features = [ "big-parallel" ];
-
-  networking.hostName = "darwin01";
 
   system.stateVersion = 4;
 }

--- a/hosts/darwin02/default.nix
+++ b/hosts/darwin02/default.nix
@@ -2,7 +2,6 @@
 
 {
   imports = [
-    inputs.self.darwinModules.common
     inputs.self.darwinModules.builder
     inputs.self.darwinModules.hercules-ci
     inputs.self.darwinModules.remote-builder
@@ -17,8 +16,6 @@
 
   # disable nixos-tests
   nix.settings.system-features = [ "big-parallel" ];
-
-  networking.hostName = "darwin02";
 
   system.stateVersion = 4;
 }

--- a/hosts/web02/default.nix
+++ b/hosts/web02/default.nix
@@ -2,12 +2,9 @@
 {
   imports = [
     ./gandi.nix
-    inputs.self.nixosModules.common
     inputs.self.nixosModules.monitoring
     inputs.srvos.nixosModules.mixins-nginx
   ];
-
-  networking.hostName = "web02";
 
   networking.useDHCP = true;
 


### PR DESCRIPTION
There are a couple of other host config flake-parts modules but IMO this one is "lite", it saves some boilerplate without needing to rearchitect the entire repo and if necessary it can be removed fairly easily.