### PR TITLE
build04: set ssh MaxStartups

### DIFF
--- a/hosts/build04/configuration.nix
+++ b/hosts/build04/configuration.nix
@@ -9,6 +9,10 @@
     inputs.self.nixosModules.remote-builder
   ];
 
+  # error: failed to start SSH connection
+  # https://github.com/nix-community/infra/issues/1416
+  services.openssh.settings.MaxStartups = 100;
+
   # set in srvos, remove when reinstalling
   networking.hostId = "deadbeef";
 


### PR DESCRIPTION
```
       MaxStartups
               Specifies the maximum number of concurrent
               unauthenticated connections to the SSH daemon.
               Additional connections will be dropped until
               authentication succeeds or the LoginGraceTime expires for
               a connection.  The default is 10:30:100.

               Alternatively, random early drop can be enabled by
               specifying the three colon separated values
               start:rate:full (e.g. "10:30:60").  sshd(8) will refuse
               connection attempts with a probability of rate/100 (30%)
               if there are currently start (10) unauthenticated
               connections.  The probability increases linearly and all
               connection attempts are refused if the number of
               unauthenticated connections reaches full (60).
```