### PR TITLE
comin: remove promethueus, alert rules

### DIFF
--- a/modules/nixos/common/comin.nix
+++ b/modules/nixos/common/comin.nix
@@ -2,8 +2,6 @@
 {
   imports = [ inputs.comin.nixosModules.comin ];
 
-  services.telegraf.extraConfig.inputs.prometheus.urls = [ "http://localhost:4243/metrics" ];
-
   services.comin = {
     enable = true;
     remotes = [

--- a/modules/nixos/monitoring/alert-rules.nix
+++ b/modules/nixos/monitoring/alert-rules.nix
@@ -13,18 +13,6 @@
         })
       )
       // {
-        CominDeploymentDifferentCommits = {
-          expr = ''count(count by (commit_id) (comin_deployment_info)) > 1'';
-          for = "90m";
-          annotations.description = "One or more comin deployments are on different commits";
-        };
-
-        CominDeploymentFailing = {
-          expr = ''comin_deployment_info{status!="done"}'';
-          for = "30m";
-          annotations.description = "{{$labels.host}} deployment failing";
-        };
-
         Filesystem80percentFull.enable = false;
 
         Filesystem95percentFull = {


### PR DESCRIPTION
https://github.com/nix-community/infra/commit/0a17c87a4f1cdafa7a0fe0a4a0a0b28b6bccbf0e reports which flake path each host is currently on so the comin monitoring isn't as useful. 