### PR TITLE
.github/workflows: remove automerge

### DIFF
--- a/.github/workflows/flake-updates.yml
+++ b/.github/workflows/flake-updates.yml
@@ -18,7 +18,3 @@ jobs:
       - name: Update flake.lock
         id: update
         uses: DeterminateSystems/update-flake-lock@v24
-      - name: Enable Automerge
-        run: gh pr merge --rebase --auto "${{ steps.update.outputs.pull-request-number }}"
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}

--- a/.github/workflows/repo-list.yml
+++ b/.github/workflows/repo-list.yml
@@ -30,8 +30,3 @@ jobs:
           commit-message: ${{ steps.setup.outputs.title }}
           title: ${{ steps.setup.outputs.title }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Enable Automerge
-        if: steps.update.outputs.pull-request-operation == 'created'
-        run: gh pr merge --rebase --auto "${{ steps.update.outputs.pull-request-number }}"
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}


### PR DESCRIPTION
Don't really need automerge for a couple of PRs and sometimes I'd rather review flake updates changes before they are merged.