### PR TITLE
modules/shared/telegraf: fix host info script

### DIFF
--- a/modules/shared/telegraf.nix
+++ b/modules/shared/telegraf.nix
@@ -1,5 +1,4 @@
 {
-  config,
   inputs,
   lib,
   pkgs,
@@ -7,7 +6,7 @@
 }:
 let
   deps = [
-    config.nix.package
+    pkgs.nixVersions.nix_2_18
     pkgs.gnused
     pkgs.jq
   ];


### PR DESCRIPTION
seems nix flake metadata breaks running as telegraf user with nix 2.24