### PR TITLE
Revert "modules/nixos/hydra: fix hydra-compress-logs"

### DIFF
--- a/modules/nixos/hydra.nix
+++ b/modules/nixos/hydra.nix
@@ -48,7 +48,6 @@
         evaluator_workers = 8
         max_concurrent_evals = 2
         max_output_size = ${builtins.toString (8 * 1024 * 1024 * 1024)}
-        compress_build_logs_compression = bzip2
       '';
     };
 


### PR DESCRIPTION
This reverts commit 5f62fc66cb735950c9f1431d37dfd8e940e23a76.

Fixed in nixpkgs.