### PR TITLE
community-builder: add btop, htop to systemPackages

### DIFF
--- a/modules/shared/community-builder.nix
+++ b/modules/shared/community-builder.nix
@@ -18,6 +18,7 @@
 
     # useful for people that want to test stuff
     environment.systemPackages = [
+      pkgs.btop
       pkgs.emacs
       pkgs.fd
       pkgs.git


### PR DESCRIPTION
For easier monitoring of system resources I propose to add [btop](https://github.com/aristocratos/btop) and `htop` to the community builders packages.
