### PR TITLE
modules/nixos/buildbot: add title, titleUrl

### DIFF
--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -57,6 +57,11 @@
     };
   };
 
+  services.buildbot-master = {
+    title = "Nix Community";
+    titleUrl = "https://nix-community.org/";
+  };
+
   sops.secrets.buildbot-nix-worker-password = { };
 
   services.buildbot-nix.worker = {


### PR DESCRIPTION
This had been broken but was fixed in buildbot 4.0.3.