### PR TITLE
modules/shared/community-builder: add terminfo packages

### DIFF
--- a/modules/darwin/community-builder/default.nix
+++ b/modules/darwin/community-builder/default.nix
@@ -13,6 +13,10 @@
 
   environment.etc.motd.text = config.nixCommunity.motd;
 
+  environment.systemPackages = [
+    pkgs.ncurses # for terminfo
+  ];
+
   programs.bash.enable = true;
 
   environment.shells = [

--- a/modules/nixos/community-builder/default.nix
+++ b/modules/nixos/community-builder/default.nix
@@ -13,14 +13,6 @@
 
   users.motd = config.nixCommunity.motd;
 
-  environment.systemPackages = [
-    # terminfo packages
-    pkgs.foot.terminfo
-    pkgs.kitty.terminfo
-    pkgs.termite.terminfo
-    pkgs.wezterm.terminfo
-  ];
-
   programs.mosh = {
     enable = true;
     withUtempter = false;

--- a/modules/shared/community-builder.nix
+++ b/modules/shared/community-builder.nix
@@ -21,18 +21,25 @@
     '';
 
     # useful for people that want to test stuff
-    environment.systemPackages = [
-      pkgs.btop
-      pkgs.emacs
-      pkgs.fd
-      pkgs.git
-      pkgs.nano
-      pkgs.nix-output-monitor
-      pkgs.nix-tree
-      pkgs.nixpkgs-review
-      pkgs.ripgrep
-      pkgs.tig
-    ];
+    environment.systemPackages =
+      [
+        pkgs.btop
+        pkgs.emacs
+        pkgs.fd
+        pkgs.git
+        pkgs.nano
+        pkgs.nix-output-monitor
+        pkgs.nix-tree
+        pkgs.nixpkgs-review
+        pkgs.ripgrep
+        pkgs.tig
+      ]
+      ++ builtins.filter (lib.meta.availableOn pkgs.stdenv.hostPlatform) [
+        pkgs.foot.terminfo
+        pkgs.kitty.terminfo
+        pkgs.termite.terminfo
+        pkgs.wezterm.terminfo
+      ];
 
     programs.nix-index-database.comma.enable = true;
 


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Will probably keep this here rather than making a shared terminfo module in srvos as there would also need to handle cross.