### PR TITLE
nixpkgs-update: add queue

### DIFF
--- a/docs/update-bot.md
+++ b/docs/update-bot.md
@@ -3,4 +3,5 @@
 - Logs: [https://nixpkgs-update-logs.nix-community.org](https://nixpkgs-update-logs.nix-community.org)
 - Nixpkgs Pull Requests: [https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+author%3Ar-ryantm](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+author%3Ar-ryantm)
 - Matrix: [https://matrix.to/#/#nixpkgs-update:nixos.org](https://matrix.to/#/#nixpkgs-update:nixos.org)
+- Queue: [https://nixpkgs-update-logs.nix-community.org/~supervisor/queue.html](https://nixpkgs-update-logs.nix-community.org/~supervisor/queue.html)
 - Source: [https://github.com/nix-community/nixpkgs-update](https://github.com/nix-community/nixpkgs-update)

--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -241,6 +241,30 @@ in
     '';
   };
 
+  systemd.services.nixpkgs-update-queue = {
+    after = [ config.systemd.services.nixpkgs-update-supervisor.name ];
+    wantedBy = [ config.systemd.targets.multi-user.name ];
+
+    serviceConfig = {
+      Type = "simple";
+      User = "r-ryantm";
+      Group = "r-ryantm";
+      Restart = "on-failure";
+      RestartSec = "5s";
+      LogsDirectory = "nixpkgs-update/";
+      LogsDirectoryMode = "755";
+      RuntimeDirectory = "nixpkgs-update-queue";
+      RuntimeDirectoryMode = "755";
+    };
+
+    path = [ pkgs.python3 ];
+
+    script = ''
+      cd "$LOGS_DIRECTORY/~supervisor"
+      python3 ${./update_queue.py}
+    '';
+  };
+
   systemd.services.nixpkgs-update-delete-old-logs = {
     startAt = "daily";
     # delete logs older than 18 months, delete worker logs older than 3 months, delete empty directories

--- a/hosts/build02/update_queue.py
+++ b/hosts/build02/update_queue.py
@@ -1,0 +1,78 @@
+import sqlite3
+import time
+from datetime import datetime, timezone
+
+
+def get_db_connection(db_path):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def fetch_queue_data(conn):
+    query = """
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY last_started ASC) AS number,
+        attr_path,
+        payload
+    FROM
+        'queue'
+    ORDER BY
+        last_started ASC
+    """
+    return conn.execute(query).fetchall()
+
+
+def generate_html_table(rows):
+    table_rows = "".join(
+        f"""
+        <tr>
+            <td>{row['number']}</td>
+            <td>{row['attr_path']}</td>
+            <td>{row['payload']}</td>
+        </tr>
+        """
+        for row in rows
+    )
+    return table_rows
+
+
+def export_html(db_path):
+    with get_db_connection(db_path) as conn:
+        results = fetch_queue_data(conn)
+
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    html = f"""
+    <html>
+    <head>
+        <title>nixpkgs-update queue</title>
+    </head>
+    <body>
+        <h1>nixpkgs-update queue</h1>
+        <h3>this page is updated every 15 minutes, last updated: {generated}</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>number</th>
+                    <th>attribute path</th>
+                    <th>payload</th>
+                </tr>
+            </thead>
+            <tbody>
+                {generate_html_table(results)}
+            </tbody>
+        </table>
+    </body>
+    </html>
+    """
+
+    with open("queue.html", "w") as f:
+        f.write(html)
+
+
+if __name__ == "__main__":
+    DB_PATH = "state.db"
+    while True:
+        export_html(DB_PATH)
+        time.sleep(15 * 60)


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

> it is technically possible for you to download the supervisor SQLite state database from https://nixpkgs-update-logs.nix-community.org/~supervisor/state.db and issue the appropriate queries against it (after having studied https://github.com/nix-community/infra/blob/master/hosts/build02/supervisor.py to understand the queue schema). But it's not exactly end-user friendly at the moment. (Some day I may publish a dashboard.)

@rhendric I thought I'd throw together something basic so people don't need to play around with the database. I'm fine with replacing this with your dashboard, if you do make one.

https://nixpkgs-update-logs.nix-community.org/~supervisor/queue.html