### PR TITLE
terraform/hydra-projects: add microvm.nix

### DIFF
--- a/terraform/hydra-projects.tf
+++ b/terraform/hydra-projects.tf
@@ -69,3 +69,30 @@ resource "hydra_project" "simple_nixos_mailserver" {
     value = "https://gitlab.com/simple-nixos-mailserver/nixos-mailserver"
   }
 }
+
+resource "hydra_project" "microvm_nix" {
+  name         = "microvm-nix"
+  display_name = "MicroVM.nix"
+  description  = "NixOS MicroVMs"
+  homepage     = "https://github.com/astro/microvm.nix"
+  owner        = "admin"
+  enabled      = true
+  visible      = true
+}
+
+resource "hydra_jobset" "microvm_nix" {
+  project     = hydra_project.microvm_nix.name
+  state       = "enabled"
+  visible     = true
+  name        = "main"
+  type        = "flake"
+  description = "main branch"
+
+  flake_uri = "github:astro/microvm.nix"
+
+  check_interval    = 1800
+  scheduling_shares = 3000
+  keep_evaluations  = 1
+
+  email_notifications = false
+}


### PR DESCRIPTION
I saw the NixCon lightning talk yesterday and it reminded me that I'd really love to have some test runners for microvm.nix.

I don't want to move the repo to this org though for stability and vanity reasons. Is that okay?