### PR TITLE
modules/nixos/monitoring/alert-rules: remove OfBorgEvalQueue

### DIFF
--- a/modules/nixos/monitoring/alert-rules.nix
+++ b/modules/nixos/monitoring/alert-rules.nix
@@ -27,12 +27,6 @@
           expr = ''systemd_units_active_code{name="matrix-hook.service", sub!="running"}'';
           annotations.description = "{{$labels.host}} should have a running {{$labels.name}}";
         };
-
-        OfBorgEvalQueue = {
-          expr = ''ofborg_queue_evaluator_waiting > (3 * ofborg_queue_evaluator_consumers)'';
-          for = "1h";
-          annotations.description = "ofborg evaluator queue is more than 3x the number of evaluators";
-        };
       };
   };
 }


### PR DESCRIPTION
no point in keeping this when ofborg is in such a bad state that it fires continuously

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
