### PR TITLE
modules/nixos/monitoring: import hosts from knownHosts

### DIFF
--- a/modules/nixos/monitoring/hosts.nix
+++ b/modules/nixos/monitoring/hosts.nix
@@ -1,9 +1,0 @@
-[
-  "build01.nix-community.org"
-  "build02.nix-community.org"
-  "build03.nix-community.org"
-  "build04.nix-community.org"
-  "darwin01.nix-community.org"
-  "darwin02.nix-community.org"
-  #"web02.nix-community.org"
-]

--- a/modules/nixos/monitoring/telegraf.nix
+++ b/modules/nixos/monitoring/telegraf.nix
@@ -1,3 +1,4 @@
+{ inputs, ... }:
 {
   services.telegraf.extraConfig.inputs = {
     http_response = [
@@ -28,17 +29,17 @@
     ];
     net_response =
       let
-        hosts = import ./hosts.nix;
+        hosts = (import "${inputs.self}/modules/shared/known-hosts.nix").programs.ssh.knownHosts;
       in
       map (host: {
         protocol = "tcp";
-        address = "${host}:22";
+        address = "${toString host.hostNames}:22";
         send = "SSH-2.0-Telegraf";
         expect = "SSH-2.0";
-        tags.host = host;
+        tags.host = toString host.hostNames;
         tags.org = "nix-community";
         timeout = "10s";
-      }) hosts;
+      }) (builtins.attrValues hosts);
     prometheus.urls = [ "https://events.ofborg.org/prometheus.php" ];
   };
 }


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Rather than using another list of hosts we can reuse known hosts.