### PR TITLE
modules/nixos/builder: add io_uring kernel patch

### DIFF
--- a/modules/nixos/builder.nix
+++ b/modules/nixos/builder.nix
@@ -26,4 +26,14 @@
       value = "20480";
     }
   ];
+
+  boot.kernelPatches = [
+    {
+      patch = pkgs.fetchpatch {
+        url = "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/patch/?id=8d09a88ef9d3cb7d21d45c39b7b7c31298d23998";
+        hash = "sha256-PCHSnsF0Vrd2nOKbDApyozLu8OUXw/6u6MrGkAWVAYc=";
+      };
+    }
+  ];
+
 }


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

https://lore.kernel.org/io-uring/25c4c665-1a33-456c-93c7-8b7b56c0e6db@kernel.dk/T/#t

This patch is queued for 6.6.