### PR TITLE
modules/nixos/common/update: switch to nixos-rebuild --store-path

### DIFF
--- a/dev/nixos-rebuild-ng.patch
+++ b/dev/nixos-rebuild-ng.patch
@@ -1,0 +1,13 @@
+diff --git a/nixos_rebuild/nix.py b/nixos_rebuild/nix.py
+index c6b5b4d63c45..24f7c128d174 100644
+--- a/nixos_rebuild/nix.py
++++ b/nixos_rebuild/nix.py
+@@ -707,6 +707,8 @@ def switch_to_configuration(
+             "not working in target host"
+         )
+         cmd = []
++    elif os.environ.get("NIXOS_REBUILD_NO_SYSTEMD_RUN"):
++        cmd = []
+
+     run_wrapper(
+         [*cmd, path_to_config / "bin/switch-to-configuration", str(action)],

--- a/dev/packages.nix
+++ b/dev/packages.nix
@@ -1,5 +1,6 @@
 {
   final,
+  prev,
   ...
 }:
 {
@@ -7,6 +8,11 @@
     ps.deploykit
     ps.invoke
   ]);
+  nixos-rebuild-ng = prev.nixos-rebuild-ng.overrideAttrs (o: {
+    patches = o.patches or [ ] ++ [
+      ./nixos-rebuild-ng.patch
+    ];
+  });
   rfc39 = final.rustPlatform.buildRustPackage {
     pname = "rfc39";
     version = "0-unstable-2025-05-21";

--- a/modules/nixos/common/update.bash
+++ b/modules/nixos/common/update.bash
@@ -2,6 +2,8 @@ arch=$(uname -m)
 hostname=$(uname -n)
 p=$(curl -L https://buildbot.nix-community.org/nix-outputs/nix-community/infra/master/"$arch"-linux.host-"$hostname")
 
+export NIXOS_REBUILD_NO_SYSTEMD_RUN=1
+
 cancel_reboot() {
   if [[ -e /run/systemd/shutdown/scheduled ]]; then
     shutdown -c
@@ -15,13 +17,12 @@ if [[ "$(readlink /run/current-system)" == "$p" ]]; then
 fi
 
 nix-store --option narinfo-cache-negative-ttl 0 --realise "$p"
-nix-env --profile /nix/var/nix/profiles/system --set "$p"
 
 booted=$(sha256sum - <"$(readlink /run/booted-system)/boot-compare")
 built=$(sha256sum - <"$p/boot-compare")
 
 if [[ $booted != "$built" ]]; then
-  /nix/var/nix/profiles/system/bin/switch-to-configuration boot
+  nixos-rebuild boot --no-reexec --store-path "$p"
   # don't use kexec if system is virtualized, reboots are fast enough
   if ! systemd-detect-virt -q; then
     kexec --load "$p"/kernel --initrd="$p"/initrd --append="$(cat "$p"/kernel-params) init=$p/init"
@@ -31,5 +32,5 @@ if [[ $booted != "$built" ]]; then
   fi
 else
   cancel_reboot
-  /nix/var/nix/profiles/system/bin/switch-to-configuration switch
+  nixos-rebuild switch --no-reexec --store-path "$p"
 fi

--- a/modules/nixos/common/update.nix
+++ b/modules/nixos/common/update.nix
@@ -13,6 +13,7 @@
     serviceConfig.Type = "oneshot";
     path = [
       config.nix.package
+      config.system.build.nixos-rebuild
       config.systemd.package
       pkgs.coreutils
       pkgs.curl


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

nixos-rebuild using systemd-run suppresses the output of pre-switch checks so without the patch we lose the update diff.

I'll see about upstreaming the patch in a week or two.