### PR TITLE
Revert "modules/shared/nix-daemon: set max-silent-time, timeout"

### DIFF
--- a/modules/shared/nix-daemon.nix
+++ b/modules/shared/nix-daemon.nix
@@ -40,10 +40,5 @@ in
 
     gc.automatic = pkgs.lib.mkDefault true;
     gc.options = pkgs.lib.mkDefault "--delete-older-than 14d";
-
-    # match buildbot timeouts
-    # https://github.com/nix-community/buildbot-nix/blob/85c0b246cc96cc244e4d9889a97c4991c4593dc3/buildbot_nix/__init__.py#L1008
-    settings.max-silent-time = toString (60 * 20);
-    settings.timeout = toString (60 * 60 * 3);
   };
 }


### PR DESCRIPTION
We actually only want this on the CI hosts, not nixpkgs-update or the community builders.