### PR TITLE
users/mrcjkb: set default shell to zsh

### DIFF
--- a/modules/darwin/community-builder/users.nix
+++ b/modules/darwin/community-builder/users.nix
@@ -336,7 +336,7 @@ let
       name = "mrcjkb";
       trusted = true;
       uid = 553;
-      shell = pkgs.nushell;
+      shell = pkgs.zsh;
       keys = ./keys/mrcjkb;
     }
     {

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -101,7 +101,7 @@ let
       name = "mrcjkb";
       # lib.maintainers.mrcjkb https://github.com/mrcjkb
       trusted = true;
-      shell = pkgs.nushell;
+      shell = pkgs.zsh;
       keys = ./keys/mrcjkb;
     }
     {


### PR DESCRIPTION
Interesting failure with nushell :thinking: 

```
cannot build on 'ssh://mrcjkb@darwin-build-box.nix-community.org': error: cannot connect to 'mrcjkb@darwin-build-box.nix-community.org': Error: nu::shell::external_command

  × External command failed
   ╭─[source:1:1]
 1 │ nix-store --serve --write
   · ────┬────
   ·     ╰── Command `nix-store` not found
   ╰────
  help: Did you mean `history`?
```