### PR TITLE
modules/nixos/monitoring: switch back to separate subdomains, oauth-proxy for alertmanager

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,3 +1,3 @@
-- [monitoring.nix-community.org/alertmanager](https://monitoring.nix-community.org/alertmanager)
-- [monitoring.nix-community.org/grafana](https://monitoring.nix-community.org/grafana)
-- [monitoring.nix-community.org/prometheus](https://monitoring.nix-community.org/prometheus)
+- [alertmanager.nix-community.org/](https://alertmanager.nix-community.org/)
+- [grafana.nix-community.org/](https://grafana.nix-community.org/)
+- [prometheus.nix-community.org/](https://prometheus.nix-community.org/)

--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -1,24 +1,17 @@
-{ config, inputs, ... }:
+{ inputs, ... }:
 {
   imports = [
     inputs.srvos.nixosModules.roles-prometheus
     ./alert-rules.nix
     ./grafana.nix
     ./matrix-hook.nix
+    ./oauth2-proxy.nix
     ./prometheus.nix
     ./telegraf.nix
   ];
 
-  age.secrets.nginx-basic-auth-file = {
-    file = "${inputs.self}/secrets/nginx-basic-auth-file.age";
-    owner = "nginx";
-  };
-
   services.nginx.virtualHosts."alertmanager.nix-community.org" = {
-    locations."/" = {
-      basicAuthFile = config.age.secrets.nginx-basic-auth-file.path;
-      proxyPass = "http://localhost:9093/";
-    };
+    locations."/".proxyPass = "http://localhost:9093/";
   };
   services.nginx.virtualHosts."grafana.nix-community.org" = {
     locations."/" = {

--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -14,16 +14,19 @@
     owner = "nginx";
   };
 
-  services.nginx.virtualHosts."monitoring.nix-community.org" = {
-    locations."/".return = "302 https://nix-community.org/monitoring";
-    locations."/alertmanager/" = {
+  services.nginx.virtualHosts."alertmanager.nix-community.org" = {
+    locations."/" = {
       basicAuthFile = config.age.secrets.nginx-basic-auth-file.path;
       proxyPass = "http://localhost:9093/";
     };
-    locations."/grafana/" = {
+  };
+  services.nginx.virtualHosts."grafana.nix-community.org" = {
+    locations."/" = {
       proxyPass = "http://localhost:3000/";
       proxyWebsockets = true;
     };
-    locations."/prometheus/".proxyPass = "http://localhost:9090/";
+  };
+  services.nginx.virtualHosts."prometheus.nix-community.org" = {
+    locations."/".proxyPass = "http://localhost:9090/";
   };
 }

--- a/modules/nixos/monitoring/grafana.nix
+++ b/modules/nixos/monitoring/grafana.nix
@@ -32,8 +32,8 @@
       };
 
       server = {
-        root_url = "https://monitoring.nix-community.org/grafana/";
-        domain = "monitoring.nix-community.org";
+        root_url = "https://grafana.nix-community.org/";
+        domain = "grafana.nix-community.org";
         enforce_domain = true;
         enable_gzip = true;
       };

--- a/modules/nixos/monitoring/oauth2-proxy.nix
+++ b/modules/nixos/monitoring/oauth2-proxy.nix
@@ -1,0 +1,24 @@
+{ config, inputs, ... }:
+{
+  age.secrets.oauth2-proxy-key-file = {
+    file = "${inputs.self}/secrets/oauth2-proxy-key-file.age";
+    owner = "oauth2-proxy";
+  };
+
+  # https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/github
+  services.oauth2-proxy = {
+    enable = true;
+    provider = "github";
+    github = {
+      org = "nix-community";
+      team = "admin";
+    };
+    clientID = "Ov23liKOQPREko8sCk6F";
+    keyFile = config.age.secrets.oauth2-proxy-key-file.path;
+    nginx.domain = "alertmanager.nix-community.org";
+    nginx.virtualHosts = {
+      "alertmanager.nix-community.org" = { };
+    };
+    email.domains = [ "*" ];
+  };
+}

--- a/modules/nixos/monitoring/prometheus.nix
+++ b/modules/nixos/monitoring/prometheus.nix
@@ -12,10 +12,9 @@
   services.prometheus = {
     enable = true;
     checkConfig = true;
-    webExternalUrl = "https://monitoring.nix-community.org/prometheus/";
+    webExternalUrl = "https://prometheus.nix-community.org/";
     extraFlags = [
       "--storage.tsdb.retention.time=30d"
-      "--web.route-prefix=/"
     ];
     scrapeConfigs = [
       {
@@ -46,11 +45,10 @@
 
   services.prometheus.alertmanager = {
     enable = true;
-    webExternalUrl = "https://monitoring.nix-community.org/alertmanager/";
+    webExternalUrl = "https://alertmanager.nix-community.org/";
     listenAddress = "[::1]";
     extraFlags = [
       "--cluster.listen-address=''"
-      "--web.route-prefix=/"
     ];
     configuration = {
       route = {

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -8,7 +8,6 @@ accounts:
     - name: ENC[AES256_GCM,data:BGA/HMgie64=,iv:c+utmChiZA73GRS4uzZDyfdU+DZaDpB3WljC2uye8o0=,tag:lr1w5TWr05lpfBNLK0Swxw==,type:str]
       totpsecret: ENC[AES256_GCM,data:Q5aJq9sLmW/0oMIgy4FErA==,iv:cFhVj/QV4tMjvB/Y8ExOSSLArvjxCV8+39YtMaADK04=,tag:aPJFH7WhaBYAW7eYsGzGYg==,type:str]
 emergency_access_password: ENC[AES256_GCM,data:ELpkrEQjFQwDicz3WeJoivrZBAWeAKkfFg==,iv:rzbKvnS5IBjUCCT2NAHINZs60F0jrRPJvZ1wnBa6xkI=,tag:hWax9+gTRhuhtIikP/jO/Q==,type:str]
-nginx-basic-auth-password: ENC[AES256_GCM,data:THXCfzuXXEsEARk1Hz4eEtzqqzzbf/IF0hHy,iv:mvOu8CSomzUYzpt1PkhSeBMgwHluUtTQZHozi6Am+RM=,tag:itQJu7Dp/N48BJMYTleuqw==,type:str]
 ssh_host_ed25519_key:
     build01: ENC[AES256_GCM,data:5rG0+Iw8uVKXTrT5A/uvbz9MJZHPyTBPKIxSbMIgvwEVHDsCENDihxL5C00PisZ4dgMIW1WQIvD3zLtJ5RxedY832K9dwO36lWH2uHZW96qlObnTqMpi0vtsZQ1FQVUtNWPj146uz7QyasisFu6CFFMBBbx6y5ZAipfJ+bsth7YliCMPL+1bM84b8a40m3k9gI4xpYH9txrq1+yvTLau25rNsmAq4oHDGKEZqRoN2WflBZLP0DL3zQ/8uPODUjOmyFpKnbDeKsDQ3RuFcPaLZOGEBruayYldxiv215pdFgw72TbvtLXc726y7bUTOvsOiLfVMdfiXZCRPzVbjGB+NLtiyz9hlCa5WdJrQmLceqC/v5zy1TbV0azlZCDNopw1yznLn8fPA8KIYJUGw+PkdKPDFKRn+F78+5QG4wpYFK9qZ/vaukvpuZrUdboFIU/qFdjplrGhniYfbh7enIGhnd2Y+qLC92IG0SQPVpI2fQNx7h3MD2V9w2spk8hZ4QGWsA4JU0fJ9mKY4w6eElGLggzT15vuCrrJx4zbThSfyVYHmlE=,iv:ksSPKFNHdy646BU2x0fr6ey+kif1jpPhlsQ5Kmxjqd4=,tag:2SL/1x4/9LoNqfHPMk8H8Q==,type:str]
     build02: ENC[AES256_GCM,data:kwc1rs7xbKod7+vV9yDNqAZMmTqencDe6LTMqxihNLuvGny1atjJ/4cf2vnWEyPar4AvqLtawbIexowbpgyzIiJBKskw0voUgUan0TMH7dsjeZtcdnBSsGWDlcBSjq8bK+yfNMWxwaq7FB9eTJkhN41UhQwqXIVpitEJg0LQcz7+BeQnYhCMnMOc+AG78zIZK+lbzAikejFJUV1A0/kmEl9VirBTpGqxhsiPUSCpAq9c3mE16f31YF9bUn9Dr/4gLW42xxbt/+6psDstKlKgfldzC+izCCCfL1qKcKz7RtyLX37O1MkQqLWvC5I5XRt81tKPOgmtjtGSM0iYmx9zy6FKGJlWqHGNb5K+g1NugWuKMzkBQNoWIypS/yHUY9R3eLa6JJM+tfE/Hvw4Q6/4HGBePMauULd/sgTC8D6o+6023a9ZdC6vdwAWzgWzhbG8uN8vjRR9JKy8/tzgzWJsR4PvPFw9ka0HbRMjigmMxZ817Z6iB2BcO2xmJvD5hP2YpPKCNLQzUznq0vh1s91C,iv:cQERNZJUQ0TJW0pbEzJF6O+1Idkt2e+I06+Kjygr4lk=,tag:2X4KhuEd/0153sCT7qeyqQ==,type:str]
@@ -112,8 +111,8 @@ sops:
             MkcvL1JyVFBJV0Y5RFFCMGN1OUFXdU0Kdx1wy6ZOOTg1a6VKaq52SMBvC26lMsW/
             oMP+hmXc2WtoqZp+jZ9rrXz6cZW6/dO7CPqxl3aUEKg6BkXIwgyKeg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-10-26T00:28:59Z"
-    mac: ENC[AES256_GCM,data:Ds3v0YTPxlpV+QTtRs1Lq3LyvnVXVU4Hp37mGOwrAgD76ek19dyMPVeJu1Q9QZwYcoSrq7GccQvo/GfTM+WVxW48B3aH+qeUye9RcdV6SYLmtQANhUyyBQurzyN7sJt2qyOWsE/VpF3NViUMkVYhLqwd/wYIiaEVmCaEpkjHp38=,iv:Vhoj+Vm8n8VcQZhmGOZU9OVZ0S+VxrZEZ178yx8aezk=,tag:D4p7Az+LqC7eQkI2QIyVfA==,type:str]
+    lastmodified: "2024-11-24T01:03:20Z"
+    mac: ENC[AES256_GCM,data:XA6/nsjHlpn7kgFPdifYKdWgswuq6vXmIBpzfRAPgucYZiaxWhinuv5tXKXgI5b0wPwVWb40l6poE2qA5ExOXKV5tzk0uPEaNVlPDEB5z24Ya5eXhOWMhxlSlfeCM+xPyY/egsFhg/Ewm0eax/nHKsZYOZw7a9RYr2Ch42G6xk4=,iv:smuKPEdbHGg4JH27mOsFulSLu0ATJsjX0oZe9LlGBPQ=,tag:HA34KNDy7yrkkBqie+CIGA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.9.1

--- a/secrets/nginx-basic-auth-file.age
+++ b/secrets/nginx-basic-auth-file.age
@@ -1,20 +1,0 @@
-age-encryption.org/v1
--> ssh-ed25519 meza2g tOhoYzkG+lCD2ONeWe32iOT+qCOvFFM2MOSTMw86ck4
-N4xw2JWB0BvQy12lIb1CS4QifkiFCHHHYBep9XzhpFI
--> ssh-rsa ALNSWw
-lzYsNzDw+FQRwcgk2ezjfw4fr5PundiR+As4Xa/OCsHFZa94QVhBVlFzgtB5nO8s
-wnoENRSQIkYqzJtGxAF8VGOvGpOsuIxNLNy/AvN4YeXYVvhPlpZjRmkCKpWG2r1w
-gprc+2VdUVjeUJiWYYhCZdn62yMXS0HI+aC8eLghtovl4dhWKh4sq8SMlNtzHLKZ
-D1nLY2rDNM+u00NEMMTOr879zfp4LHAsaol0HJrc3BnC1KmyYFd4dTivwVEU1X/r
-jw+mv8duQrbXJHckf8si7GuwQxsA0eDxKQb0y8F2hIMAkmAUMsvrJF0kyPS3UGyp
-qkby51wMLIOzzvcrgJ9KJQ
--> ssh-ed25519 Qi7vNw hiomOFHJB1MuK7rf6x6lDr6CvTMo3CN9x4/rYov6lD4
-ILX7g5TugewxzJuHF3Og06135rohMLs+vhnrcGlTO6s
--> ssh-ed25519 MW0fCg 5gofg/CnnH3aI7WnAMqHd5P7Gvyb9XV8M7v1FF8TdXU
-wwLUGvVGngz1rMZa0eIVSwf0TmUqQHTPjZDgubtoMgk
--> ssh-ed25519 92bXiA OcbjXruCXI43g/mJC/I65m7I/p04OHNWUXZuFa2vUEM
-5+NimqArjB+cbSNMh53LUmmBlXiecjdjcilS9zYVE2w
--> ssh-ed25519 h1lenA mtoPhHkVeGkSwirRAvcfHgwdZrmWalB8KEwBFfix2xE
-FyCMnN2MzQmuCjYF+cElRl1wAPumz8mAgJFzMcUXfk0
---- u5BHJScdFfK3/JdJs5dLFGTGUmX0wPAo5jra3cmYI1c
-`ף‏¾»¼2־›ן	־÷ָw¿¯ ּb3f²Ê6yÊ:י®ְּ1q—iAמµ‘ףל²9G´wע“WֳeSני¯™üֱmַפ~׳£ס,f„גרƒ%=ישQֽO6

--- a/secrets/oauth2-proxy-key-file.age
+++ b/secrets/oauth2-proxy-key-file.age
@@ -1,0 +1,20 @@
+age-encryption.org/v1
+-> ssh-ed25519 meza2g fzLc8IHnc4PPrzITLwBg+VOlLQvDwsJrZhOsRliZ/jc
+7GCGfgEtInqaAGISBCIBOjDGkDXbpZYXpOV3HyMt3r8
+-> ssh-rsa ALNSWw
+m3hoX1WRsEQ0M3oyavPldhx0q1VTOVCdNNgk8E6wNijHfPe4ClujH/McAaX3hDs1
+f2tnO9OH4t02p03j3cTQsEFMCorDT8qd7er0Ago2NcpVK5FOvOdnShkDAf4RGqLM
+v2CXsdoClsZoQJf59MfgGnAYQh9KzXs1mTKb+2Rv4eza4gcFucmVRuuyOpwkkwha
+iCbKJKMpJ/zymxf2InrHMkrvFoRho5DmV9X82PeXjspEMoYryVStAPlrrUjYrddV
+wXmdazvj/K/Kj7xjhakgvxQTCZbGxG5WbvPMFr2wK3FK2KJr0X0ZzigLGwfWzp+u
+ak5IV9ake9jlicFS/mUdYg
+-> ssh-ed25519 Qi7vNw sRlOqwFcfIZsyIGtBWSeAFZBb8uv/PJye57nxVVjzUs
+B+jZMYeoNNr5fn2AjUtLWB7u2EXgTZpm3F5JmNRGiTc
+-> ssh-ed25519 MW0fCg CfEoiC6q23tNDYBc/Fe64ous4qz2Nv+p/U4oM+PLFzE
+7Cca1MFSHqt/NDMQrj4w2mtLV6oUvfknLaRFk2fzYLo
+-> ssh-ed25519 92bXiA jCV9d+0AiLupdV6OqmsiocUcdmDK4Cqhxz/CsHzORww
+heBzRcZle76rd3R/fMxrLvo9di/9u/JQukmbIWK8s28
+-> ssh-ed25519 h1lenA fxkWlT1SKm3V+qSlS8XZ00llsILy3y8dvBwj9S3vtUQ
+IU8aWp4hqmxDanS1q10vVp8ve2IDOaJfiwy8MpnT7AM
+--- 3UYeJjdcLXxJiCdP/MF59YAvPMJp415A4MaHQIoaZzk
+_€M²^¯{fTè(CUÿFÁ ¦”8Ý]†:VŠGŸÿ~Ü~¦ýÌ5I³Åþ6¶þ»9µ˜·jW’0 Êç¡€•3,†Í¢ÇEÝ•¶zGÈÄwO„ürgÖkÞ–ž_…@ç©°Lu'°RÕ‰ªÏâ€®Þ +å¤B®@ÿ¢£ò„dmÁª·,ÿ÷d}´\ |âwdx»äè6÷p~-rHÚ±È(¹3Âê3j²Mùå˜pîIŸ

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -47,8 +47,8 @@ let
       build03
       web02
     ];
-    nginx-basic-auth-file = [ web02 ];
     nix-community-matrix-bot-token = [ web02 ];
+    oauth2-proxy-key-file = [ web02 ];
   };
 in
 builtins.listToAttrs (

--- a/terraform/cloudflare_nix-community_org.tf
+++ b/terraform/cloudflare_nix-community_org.tf
@@ -38,14 +38,16 @@ locals {
   }
 
   cname = {
+    "alertmanager"        = "web02.nix-community.org"
     "build-box"           = "build01.nix-community.org"
     "buildbot"            = "build03.nix-community.org"
     "darwin-build-box"    = "darwin01.nix-community.org"
     "docker"              = "zimbatm.docker.scarf.sh" # Used by nix-community/nixpkgs-docker
+    "grafana"             = "web02.nix-community.org"
     "hydra"               = "build03.nix-community.org"
-    "monitoring"          = "web02.nix-community.org"
     "nixpkgs-update-logs" = "build02.nix-community.org"
     "nur-update"          = "build03.nix-community.org"
+    "prometheus"          = "web02.nix-community.org"
   }
 }
 


### PR DESCRIPTION
reverts d4343f7ebe1f14e336fca4520b32ede7dfac3d8d

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Going back to separate subdomains as I'd like to put alertmanager behind oauth2 proxy and it is simpler to only need to include the alertmanager subdomain.

This is already deployed onto web02.