### PR TITLE
nix 2.18

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -149,8 +149,7 @@ in
 
   systemd.services.nixpkgs-update-fetch-repology = mkFetcher "repology" "${nixpkgs-update-bin} fetch-repology";
 
-  # breaks with nix 2.24
-  systemd.services.nixpkgs-update-fetch-updatescript = mkFetcher "updatescript" "${pkgs.nixVersions.nix_2_18}/bin/nix eval --raw -f ${./packages-with-update-script.nix}";
+  systemd.services.nixpkgs-update-fetch-updatescript = mkFetcher "updatescript" "${pkgs.nix}/bin/nix eval --option max-call-depth 100000 --raw -f ${./packages-with-update-script.nix}";
   systemd.services.nixpkgs-update-fetch-github = mkFetcher "github" "${inputs.nixpkgs-update-github-releases}/main.py";
 
   systemd.services.nixpkgs-update-worker1 = mkWorker "worker1";

--- a/modules/nixos/common/telegraf.nix
+++ b/modules/nixos/common/telegraf.nix
@@ -5,5 +5,11 @@
     ../../shared/telegraf.nix
   ];
 
+  #  error: creating directory '/var/empty/.cache/nix': Operation not permitted
+  users.users.telegraf = {
+    home = "/var/lib/telegraf";
+    createHome = true;
+  };
+
   networking.firewall.allowedTCPPorts = [ 9273 ];
 }

--- a/modules/shared/telegraf.nix
+++ b/modules/shared/telegraf.nix
@@ -8,7 +8,7 @@ let
   hostInfo = pkgs.writeShellApplication {
     name = "host-info";
     runtimeInputs = [
-      pkgs.nixVersions.nix_2_18
+      pkgs.nix
       pkgs.gnused
       pkgs.jq
     ];


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

This breaks with 2.25 as well.
```
$ nix eval --raw -f packages-with-update-script.nix > list
error:
       … while evaluating the file '/home/zowoq/infra/hosts/build02/packages-with-update-script.nix':

       … while calling the 'concatStringsSep' builtin
         at /nix/store/jzsjry4qqci36xk81m96g3v9kbnwsydp-source/lib/strings.nix:95:31:
           94|   */
           95|   concatMapStrings = f: list: concatStrings (map f list);
             |                               ^
           96|

       … while calling the 'map' builtin
         at /nix/store/jzsjry4qqci36xk81m96g3v9kbnwsydp-source/lib/strings.nix:95:46:
           94|   */
           95|   concatMapStrings = f: list: concatStrings (map f list);
             |                                              ^
           96|

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: stack overflow; max-call-depth exceeded
       at /nix/store/jzsjry4qqci36xk81m96g3v9kbnwsydp-source/lib/lists.nix:1607:15:
         1606|     list:
         1607|     let len = length list; in
             |               ^
         1608|     genList
```