### PR TITLE
modules/shared/remote-builder: add mandatoryFeatures, maxJobs

### DIFF
--- a/hosts/build03/builders.nix
+++ b/hosts/build03/builders.nix
@@ -1,4 +1,9 @@
-{ config, inputs, ... }:
+{
+  config,
+  inputs,
+  lib,
+  ...
+}:
 let
   inherit (inputs.self) darwinConfigurations nixosConfigurations;
 in
@@ -8,17 +13,26 @@ in
   nix.distributedBuilds = true;
   nix.buildMachines =
     map
-      (x: {
-        hostName = "${x.config.networking.hostName}.nix-community.org";
-        maxJobs = x.config.nix.settings.max-jobs;
-        protocol = "ssh-ng";
-        sshKey = config.sops.secrets.id_buildfarm.path;
-        sshUser = "nix";
-        systems = [
-          x.config.nixpkgs.hostPlatform.system
-        ] ++ (x.config.nix.settings.extra-platforms or [ ]);
-        supportedFeatures = x.config.nix.settings.system-features;
-      })
+      (
+        x:
+        let
+          mandatoryFeatures = x.config.nixCommunity.remote-builder.mandatoryFeatures;
+          systemFeatures = x.config.nix.settings.system-features;
+          # dedupe /etc/nix/machines
+          supportedFeatures = lib.lists.subtractLists mandatoryFeatures systemFeatures;
+        in
+        {
+          hostName = "${x.config.networking.hostName}.nix-community.org";
+          maxJobs = x.config.nixCommunity.remote-builder.maxJobs;
+          protocol = "ssh-ng";
+          sshKey = config.sops.secrets.id_buildfarm.path;
+          sshUser = "nix";
+          systems = [
+            x.config.nixpkgs.hostPlatform.system
+          ] ++ (x.config.nix.settings.extra-platforms or [ ]);
+          inherit mandatoryFeatures supportedFeatures;
+        }
+      )
       [
         darwinConfigurations.darwin02
         nixosConfigurations.build04

--- a/modules/shared/remote-builder.nix
+++ b/modules/shared/remote-builder.nix
@@ -21,10 +21,22 @@ let
   '';
 in
 {
-  options.nixCommunity.remote-builder.key = lib.mkOption {
-    type = lib.types.singleLineStr;
-    default = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEmdo1x1QkRepZf7nSe+OdEWX+wOjkBLF70vX9F+xf68 builder";
-    description = "ssh public key for the remote build user";
+  options.nixCommunity.remote-builder = {
+    key = lib.mkOption {
+      type = lib.types.singleLineStr;
+      default = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEmdo1x1QkRepZf7nSe+OdEWX+wOjkBLF70vX9F+xf68 builder";
+      description = "ssh public key for the remote build user";
+    };
+    mandatoryFeatures = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "mandatory features for the remote builder";
+    };
+    maxJobs = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = config.nix.settings.max-jobs;
+      description = "max jobs for the remote builder";
+    };
   };
 
   config.users.users.nix.openssh.authorizedKeys.keys = [


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

```
  nixCommunity.remote-builder.maxJobs = 1;

  nixCommunity.remote-builder.mandatoryFeatures = [ "gpu" ];

  nix.settings.max-jobs = 32;

  nix.settings.system-features = [ "gpu" ];
```

This is basically superseded now that there has been some discussion about running spot instances for cuda builds.