### PR TITLE
nixpkgs-update: add fetch-repology script, filter updates

### DIFF
--- a/hosts/build02/filter.sed
+++ b/hosts/build02/filter.sed
@@ -1,0 +1,13 @@
+# 1. replace versioned generic kernels with unversioned
+s|linuxKernel.packages.linux_[0-9_]*\.|linuxPackages.|g
+# 2. drop other kernels (hardened, xanmod, zen, etc)
+/linuxKernel.packages.linux_\w*/d
+
+# replace versioned/jit with unversioned
+s|postgresql\w*Packages|postgresqlPackages|g
+
+# replace versioned with the default version
+s|python3\w*Packages|python312Packages|g
+
+# drop > 4000 packages that can't be updated
+/rPackages.\w*/d

--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -102,7 +102,7 @@ let
       cd "$LOGS_DIRECTORY/~fetchers"
       run_name="${name}.$(date +%s).txt"
       rm -f ${name}.*.txt.part
-      ${cmd} > "$run_name.part"
+      ${cmd} | sed -f ${./filter.sed} > "$run_name.part"
       rm -f ${name}.*.txt
       mv "$run_name.part" "$run_name"
     '';

--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -109,6 +109,14 @@ let
     startAt = "0/12:10"; # every 12 hours
   };
 
+  repology = pkgs.writeShellApplication {
+    name = "repology";
+    runtimeInputs = [
+      pkgs.jq
+      pkgs.moreutils
+    ];
+    text = builtins.readFile ./repology.bash;
+  };
 in
 {
   users.groups.r-ryantm = { };
@@ -147,10 +155,9 @@ in
     script = "${nixpkgs-update-bin} delete-done --delete";
   };
 
-  systemd.services.nixpkgs-update-fetch-repology = mkFetcher "repology" "${nixpkgs-update-bin} fetch-repology";
-
-  systemd.services.nixpkgs-update-fetch-updatescript = mkFetcher "updatescript" "${pkgs.nix}/bin/nix eval --option max-call-depth 100000 --raw -f ${./packages-with-update-script.nix}";
   systemd.services.nixpkgs-update-fetch-github = mkFetcher "github" "${inputs.nixpkgs-update-github-releases}/main.py";
+  systemd.services.nixpkgs-update-fetch-repology = mkFetcher "repology" (lib.getExe repology);
+  systemd.services.nixpkgs-update-fetch-updatescript = mkFetcher "updatescript" "${pkgs.nix}/bin/nix eval --option max-call-depth 100000 --raw -f ${./packages-with-update-script.nix}";
 
   systemd.services.nixpkgs-update-worker1 = mkWorker "worker1";
   systemd.services.nixpkgs-update-worker2 = mkWorker "worker2";

--- a/hosts/build02/repology.bash
+++ b/hosts/build02/repology.bash
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+file=$(mktemp)
+>&2 echo "$file"
+
+fetch() {
+  local url="$1"
+  >&2 echo "$url"
+  curl --silent --compressed --user-agent "https://github.com/nix-community/infra" --location "$url"
+}
+
+fetch "https://repology.org/api/v1/projects/?inrepo=nix_unstable&outdated=1" >"$file"
+
+append() {
+  sleep 2
+  local last="$1"
+  local url="https://repology.org/api/v1/projects/$last/?inrepo=nix_unstable&outdated=1"
+  fetch "$url" >>"$file"
+}
+
+while true; do
+  last=$(jq --sort-keys --raw-output 'keys | last' <"$file")
+
+  append "$last"
+
+  jq --slurp add "$file" | sponge "$file"
+
+  final=$(jq --sort-keys --raw-output 'keys | last' <"$file")
+  if [[ $last == "$final" ]]; then
+    break
+  fi
+done
+
+jq -r '
+  to_entries |
+  map(select(.value | type == "array")) |
+  map({
+    name: (
+      .value |
+      map(select(.repo == "nix_unstable")) |
+      .[0] |
+      .srcname
+    ),
+    oldVersion: (
+      .value |
+      map(select(.repo == "nix_unstable" and .status == "outdated")) |
+      .[0] |
+      .version
+    ),
+    newVersion: (
+      .value |
+      map(select(.status == "newest" and .version != null)) |
+      .[0] |
+      .version
+    ),
+    url: "https://repology.org/project/\(.key)/versions"
+  }) |
+  map(select(.newVersion != null)) |
+  map("\(.name) \(.oldVersion) \(.newVersion) \(.url)") |
+  join("\n")
+' <"$file" | sort


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Closes https://github.com/nix-community/infra/issues/1192

Currently repology upstream is being rewritten in rust so I for now just going to use bash/jq, can look at rewriting it in python or rust once repology is stable.

Adding an update filter as lets the bot update packages that would otherwise create multiple PRs for the same update and also reduce time spent working on updates that don't work.