### PR TITLE
modules/nixos/buildbot: add microvm.nix

### DIFF
--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -7,6 +7,7 @@
 let
   repoAllowlist = [
     # keep-sorted start case=no
+    "astro/microvm.nix"
     "nix-community/authentik-nix"
     "nix-community/autofirma-nix"
     "nix-community/dream2nix"

--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -7,7 +7,7 @@
 let
   repoAllowlist = [
     # keep-sorted start case=no
-    "astro/microvm.nix"
+    #"astro/microvm.nix"
     "nix-community/authentik-nix"
     "nix-community/autofirma-nix"
     "nix-community/dream2nix"
@@ -59,6 +59,18 @@ in
       "cores": ${toString WORKER_COUNT}
     }]
   '';
+
+  systemd.services.update-host.enable = false;
+
+  services.buildbot-nix.master.pullBased = {
+    pollInterval = 1800;
+    repositories = {
+      "astro/microvm.nix" = {
+        url = "https://github.com/qowoz/microvm.nix.git";
+        defaultBranch = "main";
+      };
+    };
+  };
 
   services.buildbot-nix.master = {
     enable = true;

--- a/terraform/hydra-projects.tf
+++ b/terraform/hydra-projects.tf
@@ -70,33 +70,6 @@ resource "hydra_project" "simple_nixos_mailserver" {
   }
 }
 
-resource "hydra_project" "microvm_nix" {
-  name         = "microvm-nix"
-  display_name = "MicroVM.nix"
-  description  = "NixOS MicroVMs"
-  homepage     = "https://github.com/astro/microvm.nix"
-  owner        = "admin"
-  enabled      = true
-  visible      = true
-}
-
-resource "hydra_jobset" "microvm_nix" {
-  project     = hydra_project.microvm_nix.name
-  state       = "disabled"
-  visible     = true
-  name        = "main"
-  type        = "flake"
-  description = "main branch"
-
-  flake_uri = "github:astro/microvm.nix"
-
-  check_interval    = 1800
-  scheduling_shares = 3000
-  keep_evaluations  = 1
-
-  email_notifications = false
-}
-
 resource "hydra_project" "nixbsd" {
   name         = "nixbsd"
   display_name = "NixBSD"


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
Didn't start automatically so I triggered an eval manually:
```
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
warning: ignoring untrusted substituter 'https://microvm.cachix.org', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
error: flake 'git+file:///var/lib/buildbot-worker/worker-081/astro_microvm_nix_nix-eval/build' does not provide attribute 'checks'
warning: ignoring untrusted substituter 'https://microvm.cachix.org', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
error: flake 'git+file:///var/lib/buildbot-worker/worker-081/astro_microvm_nix_nix-eval/build' does not provide attribute 'checks'
warning: ignoring untrusted substituter 'https://microvm.cachix.org', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
error: flake 'git+file:///var/lib/buildbot-worker/worker-081/astro_microvm_nix_nix-eval/build' does not provide attribute 'checks'
warning: ignoring untrusted substituter 'https://microvm.cachix.org', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
error: flake 'git+file:///var/lib/buildbot-worker/worker-081/astro_microvm_nix_nix-eval/build' does not provide attribute 'checks'
error: flake 'git+file:///var/lib/buildbot-worker/worker-081/astro_microvm_nix_nix-eval/build' does not provide attribute 'checks'
warning: ignoring untrusted substituter 'https://microvm.cachix.org', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
warning: ignoring untrusted substituter 'https://microvm.cachix.org', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
error: flake 'git+file:///var/lib/buildbot-worker/worker-081/astro_microvm_nix_nix-eval/build' does not provide attribute 'checks'
warning: ignoring untrusted substituter 'https://microvm.cachix.org', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
error: flake 'git+file:///var/lib/buildbot-worker/worker-081/astro_microvm_nix_nix-eval/build' does not provide attribute 'checks'
warning: ignoring untrusted substituter 'https://microvm.cachix.org', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
error: flake 'git+file:///var/lib/buildbot-worker/worker-081/astro_microvm_nix_nix-eval/build' does not provide attribute 'checks'
warning: ignoring untrusted substituter 'https://microvm.cachix.org', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
error: flake 'git+file:///var/lib/buildbot-worker/worker-081/astro_microvm_nix_nix-eval/build' does not provide attribute 'checks'
error: flake 'git+file:///var/lib/buildbot-worker/worker-081/astro_microvm_nix_nix-eval/build' does not provide attribute 'checks'
error: worker error: error: flake 'git+file:///var/lib/buildbot-worker/worker-081/astro_microvm_nix_nix-eval/build' does not provide attribute 'checks'
```

```
$ sudo cat /var/lib/buildbot-worker/worker-081/astro_microvm_nix_nix-eval/build/buildbot-nix.toml
attribute = "hydraJobs"
```

https://github.com/qowoz/microvm.nix/commit/48436011d4a7f1aa89967fa37c9804c1a60d0a93

- ~~seems to ignore buildbot-nix.toml, works after the flake is changed to checks~~ seems to have been fixed in buildbot-nix

- eval uses a massive amount of memory