### PR TITLE
build01: switch to zfs_unstable

### DIFF
--- a/hosts/build01/default.nix
+++ b/hosts/build01/default.nix
@@ -1,4 +1,4 @@
-{ inputs, ... }:
+{ inputs, pkgs, ... }:
 {
   imports = [
     inputs.self.nixosModules.cgroups
@@ -6,6 +6,8 @@
     inputs.self.nixosModules.disko-zfs
     inputs.srvos.nixosModules.hardware-hetzner-online-amd
   ];
+
+  boot.zfs.package = pkgs.zfs_unstable;
 
   nix.settings.max-jobs = 24;
 


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

@Mic92 Do we need to make any changes for Direct I/O, looks like it is enabled by default?