### PR TITLE
modules/nixos/common/builder: switch to 6.12 kernel

### DIFF
--- a/modules/nixos/common/builder.nix
+++ b/modules/nixos/common/builder.nix
@@ -9,6 +9,8 @@
   config = lib.mkIf (lib.hasPrefix "build" config.networking.hostName) {
     nix.gc.automatic = false;
 
+    boot.kernelPackages = pkgs.linuxKernel.packages.linux_6_12;
+
     systemd.services.free-space = {
       serviceConfig.Type = "oneshot";
       startAt = "hourly";


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

zfs 2.2.7 added support for 6.12 kernel.