### PR TITLE
modules/nixos/common/builder: add rasdaemon

### DIFF
--- a/modules/nixos/common/builder.nix
+++ b/modules/nixos/common/builder.nix
@@ -14,6 +14,9 @@
     # kernel samepage merging
     hardware.ksm.enable = true;
 
+    hardware.rasdaemon.enable = true;
+    services.telegraf.extraConfig.inputs.ras = { };
+
     systemd.services.free-space = {
       serviceConfig.Type = "oneshot";
       startAt = "hourly";


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

https://github.com/nix-community/infra/issues/1619


```
[zowoq@build04:~]$ ras-mc-ctl --status
ras-mc-ctl: drivers not loaded.
```

The current version in nixpkgs is a year old, I'll wait for the newer version in https://nixpkgs-tracker.ocfox.me/?pr=369375 to land.