### PR TITLE
Revert "modules/nixos/common/update: use grub.extraInstallCommands for boot diff"

### DIFF
--- a/modules/nixos/common/update.bash
+++ b/modules/nixos/common/update.bash
@@ -12,6 +12,11 @@ nix-env --profile /nix/var/nix/profiles/system --set "$p"
 booted="$(readlink /run/booted-system/{initrd,kernel,kernel-modules} && cat /run/booted-system/kernel-params)"
 built="$(readlink "$p"/{initrd,kernel,kernel-modules} && cat "$p"/kernel-params)"
 if [[ $booted != "$built" ]]; then
+  if [[ -e /run/current-system ]]; then
+    echo "--- diff to current-system"
+    nvd diff /run/current-system "$p"
+    echo "---"
+  fi
   /nix/var/nix/profiles/system/bin/switch-to-configuration boot
   # don't use kexec if system is virtualized, reboots are fast enough
   if ! systemd-detect-virt -q; then

--- a/modules/nixos/common/update.nix
+++ b/modules/nixos/common/update.nix
@@ -16,19 +16,10 @@
       pkgs.coreutils
       pkgs.curl
       pkgs.kexec-tools
+      pkgs.nvd
     ];
     script = builtins.readFile ./update.bash;
   };
-
-  # https://gist.github.com/Ma27/6650d10f772511931647d3189b3eb1d7
-  # https://github.com/NuschtOS/nixos-modules/blob/39d26dddae2f117d7f9c33dd1efc866ff684ff94/modules/nix.nix
-  boot.loader.grub.extraInstallCommands = ''
-    if [[ "''${NIXOS_ACTION-}" == boot && -e /run/current-system && -e "''${1-}" ]]; then
-      echo "--- diff to current-system"
-      ${pkgs.nvd}/bin/nvd --nix-bin-dir=${config.nix.package}/bin diff /run/current-system "''${1-}"
-      echo "---"
-    fi
-  '';
 
   systemd.timers.update-host = {
     wantedBy = [ "timers.target" ];


### PR DESCRIPTION
This reverts commit 01137d599d5bccdb0f3399d51930534f0a7c05c3.

I noticed that this breaks the disko installTest so probably want to find any way to do this.

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
