### PR TITLE
modules/nixos/common: use preSwitchChecks for update diff

### DIFF
--- a/modules/nixos/common/default.nix
+++ b/modules/nixos/common/default.nix
@@ -17,6 +17,15 @@
     inputs.srvos.nixosModules.server
   ];
 
+  srvos.update-diff.enable = false;
+  system.preSwitchChecks.update-diff = ''
+    if [[ -e /run/current-system && -e "''${1-}" ]]; then
+      echo "--- diff to current-system"
+      ${pkgs.nvd}/bin/nvd --nix-bin-dir=${config.nix.package}/bin diff /run/current-system "''${1-}"
+      echo "---"
+    fi
+  '';
+
   # Hard-link duplicated files
   nix.settings.auto-optimise-store = true;
   nix.optimise.automatic = false;

--- a/modules/nixos/common/update.bash
+++ b/modules/nixos/common/update.bash
@@ -12,11 +12,6 @@ nix-env --profile /nix/var/nix/profiles/system --set "$p"
 booted="$(readlink /run/booted-system/{initrd,kernel,kernel-modules} && cat /run/booted-system/kernel-params)"
 built="$(readlink "$p"/{initrd,kernel,kernel-modules} && cat "$p"/kernel-params)"
 if [[ $booted != "$built" ]]; then
-  if [[ -e /run/current-system ]]; then
-    echo "--- diff to current-system"
-    nvd diff /run/current-system "$p"
-    echo "---"
-  fi
   /nix/var/nix/profiles/system/bin/switch-to-configuration boot
   # don't use kexec if system is virtualized, reboots are fast enough
   if ! systemd-detect-virt -q; then

--- a/modules/nixos/common/update.nix
+++ b/modules/nixos/common/update.nix
@@ -16,7 +16,6 @@
       pkgs.coreutils
       pkgs.curl
       pkgs.kexec-tools
-      pkgs.nvd
     ];
     script = builtins.readFile ./update.bash;
   };


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Second attempt at adding a boot diff (https://github.com/nix-community/infra/pull/1609) but using preSwitchChecks (https://github.com/NixOS/nixpkgs/commit/6e192c4489ea44c48876faa11060798fb9502146) which works for boot/switch, grub/systemd-boot and has an escape hatch which can be used for things like disko install tests, nixos-anywhere, etc.

I've move this to srvos after we've tested it here for a bit.