### PR TITLE
modules/nixos/common/builder: switch back to 6.6 kernel

### DIFF
--- a/hosts/build03/default.nix
+++ b/hosts/build03/default.nix
@@ -1,4 +1,4 @@
-{ inputs, pkgs, ... }:
+{ inputs, ... }:
 {
   imports = [
     ./builders.nix
@@ -15,8 +15,6 @@
     inputs.self.nixosModules.watch-store
     inputs.srvos.nixosModules.hardware-hetzner-online-amd
   ];
-
-  boot.kernelPackages = pkgs.lib.mkForce pkgs.linuxKernel.packages.linux_6_6;
 
   nix.settings.max-jobs = 96;
 

--- a/modules/nixos/common/builder.nix
+++ b/modules/nixos/common/builder.nix
@@ -9,7 +9,7 @@
   config = lib.mkIf (lib.hasPrefix "build" config.networking.hostName) {
     nix.gc.automatic = false;
 
-    boot.kernelPackages = pkgs.linuxKernel.packages.linux_6_12;
+    boot.kernelPackages = pkgs.linuxKernel.packages.linux_6_6;
 
     # kernel samepage merging
     hardware.ksm.enable = true;


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
 
Not completely sure it is the kernel but aarch64-linux seems to be worse the last couple of weeks, crashing or freezing.