### PR TITLE
nixos/community-builder: add misuzu

### DIFF
--- a/modules/nixos/community-builder/keys/misuzu
+++ b/modules/nixos/community-builder/keys/misuzu
@@ -1,0 +1,3 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILPxq3an5irer/8bjJFK0ZzXbOExSp/T7DNsLx/xtMBj misuzu@erika
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH/k1reOfT7csrtHnbp9ti+oyBlY8sS4DEeRmhJRPFJe misuzu@naomi
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMdt9QlwUdAJ7RtSvAXuBUNmSiTn5aOTsmfhtA3OtUcQ misuzu@buildbox

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -103,6 +103,12 @@ let
       keys = ./keys/linj;
     }
     {
+      name = "misuzu";
+      # lib.maintainers.misuzu https://github.com/misuzu
+      trusted = true;
+      keys = ./keys/misuzu;
+    }
+    {
       name = "mrcjkb";
       # lib.maintainers.mrcjkb https://github.com/mrcjkb
       trusted = true;


### PR DESCRIPTION
I've [used](https://github.com/NixOS/aarch64-build-box/blob/05298da5e1c3bed11448241134e0f1e8bcef0a1e/users.nix#L371) https://github.com/NixOS/aarch64-build-box before, but it's gone now and testing big packages on my rpi4 is a pain... 

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
