### PR TITLE
modules/nixos/hercules-ci: set TimeoutStopSec

### DIFF
--- a/modules/nixos/hercules-ci.nix
+++ b/modules/nixos/hercules-ci.nix
@@ -21,4 +21,7 @@ in
       secretsJsonPath = config.sops.secrets.hercules-secrets.path;
     };
   };
+
+  # State 'stop-sigterm' timed out. Killing.
+  systemd.services.hercules-ci-agent.serviceConfig.TimeoutStopSec = 15;
 }


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Takes 90 seconds to timeout before being killed. Only happens intermittently.  

```
Jan 22 05:04:56 build03 systemd[1]: Stopping hercules-ci-agent.service...
Jan 22 05:06:26 build03 systemd[1]: hercules-ci-agent.service: State 'stop-sigterm' timed out. Killing.
Jan 22 05:06:26 build03 systemd[1]: hercules-ci-agent.service: Killing process 51552 (hercules-ci-age) with signal SIGKILL.
Jan 22 05:06:26 build03 systemd[1]: hercules-ci-agent.service: Killing process 51571 (hercules-ci-age) with signal SIGKILL.
Jan 22 05:06:26 build03 systemd[1]: hercules-ci-agent.service: Killing process 1935631 (ghc_worker) with signal SIGKILL.
Jan 22 05:06:26 build03 systemd[1]: hercules-ci-agent.service: Killing process 1937690 (n/a) with signal SIGKILL.
Jan 22 05:06:26 build03 systemd[1]: hercules-ci-agent.service: Killing process 1942266 (n/a) with signal SIGKILL.
Jan 22 05:06:26 build03 systemd[1]: hercules-ci-agent.service: Killing process 1942409 (n/a) with signal SIGKILL.
Jan 22 05:06:26 build03 systemd[1]: hercules-ci-agent.service: Killing process 1942416 (n/a) with signal SIGKILL.
Jan 22 05:06:27 build03 systemd[1]: hercules-ci-agent.service: Main process exited, code=killed, status=9/KILL
Jan 22 05:06:27 build03 systemd[1]: hercules-ci-agent.service: Failed with result 'timeout'.
Jan 22 05:06:27 build03 systemd[1]: Stopped hercules-ci-agent.service.
```
