### PR TITLE
modules/nixos/common: remove hung_task_panic

### DIFF
--- a/modules/nixos/common/default.nix
+++ b/modules/nixos/common/default.nix
@@ -43,7 +43,6 @@
     ];
     script = ''
       sysctl -w kernel.hardlockup_panic=1
-      sysctl -w kernel.hung_task_panic=1
       sysctl -w kernel.panic_on_oops=1
       sysctl -w kernel.panic=60
       sysctl -w kernel.softlockup_panic=1


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

A stuck hydra build can trigger this which can then cause a loop as the hydra build is restarted.

Probably useful to monitor hung tasks, I'll look into that.