### PR TITLE
modules/nixos: remove cgroup-exporter

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,26 +29,6 @@
         "type": "github"
       }
     },
-    "cgroup-exporter": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1736508617,
-        "narHash": "sha256-YV49EvJWc+uae6R3REuk/XWZfKBKzfwx1Mu0/SlmBWE=",
-        "owner": "arianvp",
-        "repo": "cgroup-exporter",
-        "rev": "30eca88d60087e2cc7e9339acbaa6fae1f167d81",
-        "type": "github"
-      },
-      "original": {
-        "owner": "arianvp",
-        "repo": "cgroup-exporter",
-        "type": "github"
-      }
-    },
     "disko": {
       "inputs": {
         "nixpkgs": [
@@ -323,7 +303,6 @@
     "root": {
       "inputs": {
         "buildbot-nix": "buildbot-nix",
-        "cgroup-exporter": "cgroup-exporter",
         "disko": "disko",
         "empty": "empty",
         "flake-compat": "flake-compat",

--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,6 @@
     buildbot-nix.inputs.nixpkgs.follows = "nixpkgs";
     buildbot-nix.inputs.treefmt-nix.follows = "treefmt-nix";
     buildbot-nix.url = "github:nix-community/buildbot-nix";
-    cgroup-exporter.inputs.nixpkgs.follows = "nixpkgs";
-    cgroup-exporter.url = "github:arianvp/cgroup-exporter";
     disko.inputs.nixpkgs.follows = "nixpkgs";
     disko.url = "github:nix-community/disko";
     empty.url = "github:nix-systems/empty";

--- a/modules/nixos/cgroups.nix
+++ b/modules/nixos/cgroups.nix
@@ -1,20 +1,8 @@
 {
-  config,
-  inputs,
   pkgs,
   ...
 }:
 {
-  imports = [
-    inputs.cgroup-exporter.nixosModules.default
-  ];
-
-  services.prometheus.exporters.cgroup.enable = true;
-
-  services.telegraf.extraConfig.inputs.prometheus.urls = [
-    "http://localhost:${toString config.services.prometheus.exporters.cgroup.port}/metrics"
-  ];
-
   nix = {
     package = pkgs.nixVersions.nix_2_25;
 


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Removing this as it was never really used and the telegraf cgroup plugin will have better support for v2 cgroups in the next version (1.34.0) that we cloud use instead.