### PR TITLE
nixos/community-builder: add booxter

### DIFF
--- a/modules/nixos/community-builder/keys/booxter
+++ b/modules/nixos/community-builder/keys/booxter
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA0W1oVd2GMoSwXHVQMb6v4e3rIMVe9/pr/PcsHg+Uz3 ihrachys@ihrachys-macpro

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -281,6 +281,12 @@ let
       trusted = true;
       keys = ./keys/nilp0inter;
     }
+    {
+      # lib.maintainers.booxter, https://github.com/booxter
+      name = "booxter";
+      trusted = true;
+      keys = ./keys/booxter;
+    }
   ];
 in
 {


### PR DESCRIPTION
I already had access to darwin builder; I now need nixos because my
machine is not capable enough to survive a firefox build anymore.

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
