### PR TITLE
nixpkgs-update: use nixos-unstable instead of master for updateScript fetcher, run github fetcher every 6 hours

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -170,7 +170,11 @@ in
     script = "${nixpkgs-update-bin} delete-done --delete";
   };
 
-  systemd.services.nixpkgs-update-fetch-github = mkFetcher "github" "${inputs.nixpkgs-update-github-releases}/main.py";
+  systemd.services.nixpkgs-update-fetch-github =
+    mkFetcher "github" "${inputs.nixpkgs-update-github-releases}/main.py"
+    // {
+      startAt = "0/6:10"; # every 6 hours
+    };
   systemd.services.nixpkgs-update-fetch-repology = mkFetcher "repology" (lib.getExe repology);
   systemd.services.nixpkgs-update-fetch-updatescript = mkFetcher "updatescript" "${pkgs.nix}/bin/nix eval --option max-call-depth 100000 --raw -f ${./packages-with-update-script.nix}";
 

--- a/hosts/build02/packages-with-update-script.nix
+++ b/hosts/build02/packages-with-update-script.nix
@@ -1,5 +1,5 @@
 let
-  pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/master.tar.gz") { config.allowAliases = false; };
+  pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz") { config.allowAliases = false; };
 in
 # code in the following let block was copied from nixos/nixpkgs under
   # the MIT License


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
