### PR TITLE
modules/community-builder: add grimmauld

### DIFF
--- a/modules/nixos/community-builder/keys/grimmauld
+++ b/modules/nixos/community-builder/keys/grimmauld
@@ -1,0 +1,1 @@
+sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIMgGKExPve3tsl0/kjV5rCo5wb46CapnUaA1ZdZWpgXTAAAAC3NzaDpnZW5lcmFs grimmauld@grimm-nixos-ssd

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -72,6 +72,12 @@ let
       keys = ./keys/glepage;
     }
     {
+      # lib.maintainers.grimmauld, https://github.com/lordgrimmauld
+      name = "grimmauld";
+      trusted = true;
+      keys = ./keys/grimmauld;
+    }
+    {
       name = "hadilq";
       trusted = true;
       keys = ./keys/hadilq;


### PR DESCRIPTION
I am active building AppArmor support for NixOS, and libapparmor changes cause a mass rebuild which makes testing on my personal laptop not exactly viable.
I also recently started looking into deprecating SDL1 (for SDL12_compat), which also causes mass rebuilds.
Most recently, i wanted to experiment with custom compiles of firefox, including updating LibreWolf to the most recent version, but compiling firefox is too big a compile task.

I already had a chat with people from the community a while ago (emily and hexa, i think? i don't quite remember), and got the suggestion to sign up for community builders.
I declined at the time, referring to other IRL obligations currently taking up my time. However, i have now decided having the access can't hurt, and will be useful. Especially considering AppArmor 4.x versions are close to release upstream.

I already joined the matrix room a while ago.

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
