### PR TITLE
nixos/community-builder: add user craige

### DIFF
--- a/modules/nixos/community-builder/keys/craige
+++ b/modules/nixos/community-builder/keys/craige
@@ -1,0 +1,2 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDtjE0YstRzlh+Zhlj03th9DYOkMqJ5xHUcderBq151K craige@mcwhirter.io
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILv1UfUVhTy9SSSobXEzP311Tnh3hL3hk5LVwat5QfVl colmena@mcwhirter.io

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -45,6 +45,11 @@ let
       keys = ./keys/ckie;
     }
     {
+      name = "craige";
+      trusted = true;
+      keys = ./keys/craige;
+    }
+    {
       name = "dandellion";
       trusted = true;
       keys = ./keys/dandellion;


### PR DESCRIPTION
I used to have [access to the old aarch64-build-box](https://github.com/NixOS/aarch64-build-box/blob/master/keys/craige) and came back from holidays in late January to find it was dead :sob: 

TIL that we have a replacement, so I'm requesting access so that I can resume dev work on `aarch64` and `mobile-nixos`.

Thanks :smiley: 