### PR TITLE
nixbsd freebsd builder

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,6 +137,62 @@
         "type": "github"
       }
     },
+    "lix": {
+      "inputs": {
+        "flake-compat": [
+          "nixbsd",
+          "flake-compat"
+        ],
+        "nix2container": [
+          "nixbsd"
+        ],
+        "nixpkgs": [
+          "nixbsd",
+          "nixpkgs"
+        ],
+        "nixpkgs-regression": [
+          "nixbsd"
+        ],
+        "pre-commit-hooks": [
+          "nixbsd"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741969094,
+        "narHash": "sha256-N9URV6eRf3FfWPuFHwEpTjrDBwvP9ekNPeMe5HqPycY=",
+        "ref": "freebsd-build",
+        "rev": "d003841587befb47d41373cba00d9921df8e237b",
+        "revCount": 17650,
+        "type": "git",
+        "url": "https://git.lix.systems/artemist/lix.git"
+      },
+      "original": {
+        "ref": "freebsd-build",
+        "type": "git",
+        "url": "https://git.lix.systems/artemist/lix.git"
+      }
+    },
+    "mini-tmpfiles": {
+      "inputs": {
+        "nixpkgs": [
+          "nixbsd",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741473245,
+        "narHash": "sha256-32ekQLovnjpb1NBvt1/WCEn98khSGljX+QkS+SLSNpM=",
+        "owner": "nixos-bsd",
+        "repo": "mini-tmpfiles",
+        "rev": "1ff4fc98963421e0e6b099ccda721d5a1ca4c887",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos-bsd",
+        "repo": "mini-tmpfiles",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -175,6 +231,50 @@
         "owner": "nix-community",
         "repo": "nix-index-database",
         "type": "github"
+      }
+    },
+    "nixbsd": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "lix": "lix",
+        "mini-tmpfiles": "mini-tmpfiles",
+        "nixpkgs": [
+          "nixbsd-nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1748654155,
+        "narHash": "sha256-/HT+tmZTISs0UfQ9ZCqxyK26admCv95TQvvwQqG3h+c=",
+        "owner": "qowoz",
+        "repo": "nixbsd",
+        "rev": "6de10e16330cf87ec39d8637844180ef2e0d3522",
+        "type": "github"
+      },
+      "original": {
+        "owner": "qowoz",
+        "ref": "tmp3-community",
+        "repo": "nixbsd",
+        "type": "github"
+      }
+    },
+    "nixbsd-nixpkgs": {
+      "locked": {
+        "lastModified": 1748404084,
+        "narHash": "sha256-i/oKVGbA3hvxVJwZi7dyWpyN6gGTxtq8lslPzOcLUT4=",
+        "ref": "nixbsd-dev-tmp",
+        "rev": "33d5774c0ae99ad4d62743eb004a5bd24b248791",
+        "shallow": true,
+        "type": "git",
+        "url": "https://github.com/rhelmot/nixpkgs"
+      },
+      "original": {
+        "ref": "nixbsd-dev-tmp",
+        "rev": "33d5774c0ae99ad4d62743eb004a5bd24b248791",
+        "shallow": true,
+        "type": "git",
+        "url": "https://github.com/rhelmot/nixpkgs"
       }
     },
     "nixos-facter-modules": {
@@ -295,6 +395,8 @@
         "lite-config": "lite-config",
         "nix-darwin": "nix-darwin",
         "nix-index-database": "nix-index-database",
+        "nixbsd": "nixbsd",
+        "nixbsd-nixpkgs": "nixbsd-nixpkgs",
         "nixos-facter-modules": "nixos-facter-modules",
         "nixpkgs": "nixpkgs",
         "nixpkgs-update": "nixpkgs-update",

--- a/hosts/build01/default.nix
+++ b/hosts/build01/default.nix
@@ -3,6 +3,7 @@
   imports = [
     inputs.self.nixosModules.cgroups
     inputs.self.nixosModules.community-builder
+    inputs.self.nixosModules.freebsd-builder
     inputs.self.nixosModules.disko-zfs
     inputs.srvos.nixosModules.hardware-hetzner-online-amd
   ];

--- a/hosts/freebsd/configuration.nix
+++ b/hosts/freebsd/configuration.nix
@@ -1,0 +1,107 @@
+{ config, pkgs, ... }:
+{
+  imports = [
+    ../../modules/shared/telegraf.nix
+    ./ssh.nix
+    ./telegraf-config.nix
+    ./telegraf-service.nix
+  ];
+
+  nixpkgs.buildPlatform = "x86_64-linux";
+  nixpkgs.hostPlatform = "x86_64-freebsd";
+
+  networking.hostName = "nixbsd-freebsd";
+
+  system.stateVersion = "25.05"; # silence warning
+
+  services.openssh.enable = true;
+  boot.loader.stand-freebsd.enable = true;
+  networking.dhcpcd.wait = "background";
+
+  nixbsd.enableExtraSubstituters = false;
+
+  users.users.root.initialPassword = "toor";
+
+  users.users.admin = {
+    isNormalUser = true;
+    extraGroups = [
+      "trusted"
+      "wheel"
+    ];
+    inherit (config.users.users.root) initialPassword;
+  };
+
+  boot.tmp.useTmpfs = false;
+
+  fileSystems."/" = {
+    device = "/dev/gpt/nixos";
+    fsType = "ufs";
+  };
+
+  fileSystems."/boot" = {
+    device = "/dev/msdosfs/ESP";
+    fsType = "msdosfs";
+  };
+
+  environment.systemPackages = with pkgs; [
+    file
+    freebsd.truss
+    gitMinimal
+    htop
+    jq
+    mini-tmpfiles
+    tmux
+    unzip
+    vim
+    zip
+  ];
+
+  users.users.nix = {
+    isNormalUser = true;
+    extraGroups = [ "trusted" ];
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJBWcxb/Blaqt1auOtE+F8QUWrUotiC5qBJ+UuEWdVCb root@nixos"
+    ];
+  };
+
+  users.groups.trusted = { };
+
+  nix.settings =
+    let
+      asGB = size: toString (size * 1024 * 1024 * 1024);
+    in
+    {
+      min-free = asGB 20;
+      max-free = asGB 50;
+      trusted-users = [
+        "@trusted"
+        "@wheel"
+      ];
+      experimental-features = [
+        "flakes"
+        "nix-command"
+      ];
+      substituters = [ "https://nix-community.cachix.org" ];
+      trusted-public-keys = [
+        "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      ];
+    };
+
+  virtualisation.vmVariant.virtualisation = {
+    diskImage = "./disk.qcow2";
+    rootSize = "100g";
+    graphics = false;
+    forwardPorts = [
+      {
+        from = "host";
+        host.port = 31022;
+        guest.port = 22;
+      }
+      {
+        from = "host";
+        host.port = 39273;
+        guest.port = 9273;
+      }
+    ];
+  };
+}

--- a/hosts/freebsd/ssh.nix
+++ b/hosts/freebsd/ssh.nix
@@ -1,0 +1,27 @@
+{
+  environment.etc."ssh/ssh_host_ed25519_key.pub" = {
+    mode = "0644";
+    text = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJBWcxb/Blaqt1auOtE+F8QUWrUotiC5qBJ+UuEWdVCb root@nixos";
+  };
+
+  environment.etc."ssh/ssh_host_ed25519_key" = {
+    mode = "0600";
+    # https://github.com/NixOS/nixpkgs/blob/1a4711b6be669d31f21b417a7f8b60801367dfee/nixos/modules/profiles/keys/ssh_host_ed25519_key
+    text = ''
+      -----BEGIN OPENSSH PRIVATE KEY-----
+      b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+      QyNTUxOQAAACCQVnMW/wZWqrdWrjrRPhfEFFq1KLYguagSflLhFnVQmwAAAJASuMMnErjD
+      JwAAAAtzc2gtZWQyNTUxOQAAACCQVnMW/wZWqrdWrjrRPhfEFFq1KLYguagSflLhFnVQmw
+      AAAEDIN2VWFyggtoSPXcAFy8dtG1uAig8sCuyE21eMDt2GgJBWcxb/Blaqt1auOtE+F8QU
+      WrUotiC5qBJ+UuEWdVCbAAAACnJvb3RAbml4b3MBAgM=
+      -----END OPENSSH PRIVATE KEY-----
+    '';
+  };
+
+  services.openssh.hostKeys = [
+    {
+      path = "/etc/ssh/ssh_host_ed25519_key";
+      type = "ed25519";
+    }
+  ];
+}

--- a/hosts/freebsd/telegraf-config.nix
+++ b/hosts/freebsd/telegraf-config.nix
@@ -1,0 +1,39 @@
+# srvos
+{
+  services.telegraf = {
+    enable = true;
+    extraConfig = {
+      agent.interval = "60s";
+      inputs = {
+        system = { };
+        mem = { };
+        swap = { };
+        disk.tagdrop = {
+          fstype = [
+            "tmpfs"
+            "ramfs"
+            "devtmpfs"
+            "devfs"
+            "iso9660"
+            "overlay"
+            "aufs"
+            "squashfs"
+            "efivarfs"
+          ];
+          device = [
+            "rpc_pipefs"
+            "lxcfs"
+            "nsfs"
+            "borgfs"
+          ];
+        };
+        diskio = { };
+        internal = { };
+      };
+      outputs.prometheus_client = {
+        listen = ":9273";
+        metric_version = 2;
+      };
+    };
+  };
+}

--- a/hosts/freebsd/telegraf-service.nix
+++ b/hosts/freebsd/telegraf-service.nix
@@ -1,0 +1,61 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) mkEnableOption mkOption;
+
+  cfg = config.services.telegraf;
+
+  settingsFormat = pkgs.formats.toml { };
+  configFile = settingsFormat.generate "config.toml" cfg.extraConfig;
+
+  package = pkgs.buildGo124Module rec {
+    pname = "telegraf";
+    version = "1.34.4";
+    subPackages = [ "cmd/telegraf" ];
+    src = pkgs.fetchFromGitHub {
+      owner = "influxdata";
+      repo = "telegraf";
+      rev = "v${version}";
+      hash = "sha256-oFhSCBGS8brXBxUiuXTCQiwRWuLvjDPte2Zi6BwelJs=";
+    };
+    env.CGO_ENABLED = 0;
+    vendorHash = "sha256-C4p+dZkudSIJI4036RR5J8rokEUB1Vi+xTC6Ijf9gUc=";
+    proxyVendor = true;
+    ldflags = [
+      "-s"
+      "-w"
+      "-X=github.com/influxdata/telegraf/internal.Commit=${src.rev}"
+      "-X=github.com/influxdata/telegraf/internal.Version=${version}"
+    ];
+  };
+in
+{
+  options.services.telegraf = {
+    enable = mkEnableOption "telegraf agent";
+
+    extraConfig = mkOption {
+      default = { };
+      description = "Extra configuration options for telegraf";
+      inherit (settingsFormat) type;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ package ];
+
+    environment.etc."telegraf/telegraf.conf".source = configFile;
+
+    init.services.telegraf = {
+      description = "Telegraf Agent";
+      dependencies = [ "NETWORKING" ];
+
+      startType = "foreground";
+      startCommand = [ "${package}/bin/telegraf" ];
+    };
+  };
+}

--- a/modules/nixos/freebsd-builder.nix
+++ b/modules/nixos/freebsd-builder.nix
@@ -1,0 +1,74 @@
+{ config, inputs, ... }:
+let
+  freebsdVM = inputs.self.nixbsdConfigurations."${config.networking.hostName}-freebsd";
+in
+{
+  # telegraf metrics from vm
+  networking.firewall.allowedTCPPorts = [ 39273 ];
+
+  environment.etc."nix/freebsd-builder-key" = {
+    mode = "0600";
+    # https://github.com/NixOS/nixpkgs/blob/1a4711b6be669d31f21b417a7f8b60801367dfee/nixos/modules/profiles/keys/ssh_host_ed25519_key
+    text = ''
+      -----BEGIN OPENSSH PRIVATE KEY-----
+      b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+      QyNTUxOQAAACCQVnMW/wZWqrdWrjrRPhfEFFq1KLYguagSflLhFnVQmwAAAJASuMMnErjD
+      JwAAAAtzc2gtZWQyNTUxOQAAACCQVnMW/wZWqrdWrjrRPhfEFFq1KLYguagSflLhFnVQmw
+      AAAEDIN2VWFyggtoSPXcAFy8dtG1uAig8sCuyE21eMDt2GgJBWcxb/Blaqt1auOtE+F8QU
+      WrUotiC5qBJ+UuEWdVCbAAAACnJvb3RAbml4b3MBAgM=
+      -----END OPENSSH PRIVATE KEY-----
+    '';
+  };
+
+  nix.distributedBuilds = true;
+  nix.buildMachines = [
+    {
+      hostName = "freebsd-builder";
+      maxJobs = freebsdVM.config.virtualisation.vmVariant.virtualisation.cores;
+      protocol = "ssh";
+      sshKey = "/etc/nix/freebsd-builder-key";
+      sshUser = "nix";
+      supportedFeatures = [ "big-parallel" ];
+      systems = [ "x86_64-freebsd" ];
+    }
+  ];
+
+  programs.ssh.extraConfig = ''
+    Host freebsd-builder
+      Hostname 127.0.0.1
+      HostKeyAlias freebsd-builder
+      Port 31022
+  '';
+
+  programs.ssh.knownHosts.freebsd-builder = {
+    hostNames = [ "freebsd-builder" ];
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJBWcxb/Blaqt1auOtE+F8QUWrUotiC5qBJ+UuEWdVCb root@nixos";
+  };
+
+  systemd.services.vm-builder = {
+    wantedBy = [
+      config.systemd.targets.multi-user.name
+    ];
+    path = [
+      freebsdVM.config.system.build.vm
+    ];
+    script = ''
+      rm -f *.qcow2
+      run-nixbsd-freebsd-vm
+    '';
+    serviceConfig = {
+      User = "vm-builder";
+      Group = "vm-builder";
+      Restart = "on-failure";
+      WorkingDirectory = "/var/lib/vm-builder";
+    };
+  };
+
+  users.users.vm-builder = {
+    createHome = true;
+    home = "/var/lib/vm-builder";
+    isNormalUser = true;
+    group = "vm-builder";
+  };
+  users.groups.vm-builder = { };
+}

--- a/modules/nixos/monitoring/prometheus.nix
+++ b/modules/nixos/monitoring/prometheus.nix
@@ -27,9 +27,11 @@
           in
           [
             {
-              targets = builtins.concatMap (host: map (name: "${name}:9273") host.hostNames) (
-                builtins.attrValues hosts
-              );
+              targets =
+                builtins.concatMap (host: map (name: "${name}:9273") host.hostNames) (builtins.attrValues hosts)
+                ++ [
+                  "build01.nix-community.org:39273" # build01-freebsd
+                ];
               labels.org = "nix-community";
             }
           ];

--- a/modules/shared/host-info.bash
+++ b/modules/shared/host-info.bash
@@ -1,15 +1,18 @@
-flake=$(nix flake metadata self --json | jq -r '.path' | sed -e 's|/nix/store/||' -e 's|-source||')
+flake=$(nix flake metadata self --json 2>/dev/null | jq -r '.path' | sed -e 's|/nix/store/||' -e 's|-source||')
 nix_version="$(nix store ping --store daemon --json | jq -r '.version')"
 case "$(uname -s)" in
 Darwin)
   os_version="$(/usr/bin/sw_vers --productVersion)_$(/usr/bin/sw_vers --buildVersion)"
   ;;
-Linux)
+Linux | FreeBSD)
   os_version="$(uname -r)"
   if [[ -e /run/systemd/shutdown/scheduled ]]; then
     flake=reboot
   fi
   ;;
+*)
+  os_version=null
+  ;;
 esac
 system="$(nix eval --impure --raw --expr 'builtins.currentSystem')"
-echo "host,flake=$flake,nix_version=$nix_version,os_version=$os_version,system=$system info=1"
+echo "host,flake=${flake:-null},nix_version=$nix_version,os_version=$os_version,system=$system info=1"

--- a/modules/shared/telegraf.nix
+++ b/modules/shared/telegraf.nix
@@ -8,6 +8,11 @@
 let
   hostInfo = pkgs.writeShellApplication {
     name = "host-info";
+    bashOptions = [
+      "errexit"
+      "nounset"
+    ];
+    checkPhase = lib.optional pkgs.stdenv.hostPlatform.isFreeBSD null;
     runtimeInputs = [
       config.nix.package
       pkgs.gnused
@@ -29,7 +34,7 @@ in
         name: input:
         ''flake_input_last_modified{input="${name}",${lib.concatStringsSep "," (flakeAttrs input)}} ${toString input.lastModified}'';
     in
-    {
+    lib.mkIf (!pkgs.stdenv.hostPlatform.isFreeBSD) {
       "flake-inputs.prom" = {
         text = builtins.unsafeDiscardStringContext ''
           # HELP flake_registry_last_modified Last modification date of flake input in unixtime
@@ -46,7 +51,7 @@ in
         data_format = "influx";
       }
     ];
-    file = [
+    file = lib.mkIf (!pkgs.stdenv.hostPlatform.isFreeBSD) [
       {
         data_format = "prometheus";
         files = [ "/etc/flake-inputs.prom" ];


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

- ~~currently can't build anything in the vm~~:
  -  ~~`
error: build of '/nix/store/hicd8c5cnfnzc91kjqfhwdrc2d99n9mq-bootstrap-archive.drv' on 'ssh-ng://nix@freebsd-builder' failed: error: Failed to mount nullfs for /nix/store/hicd8c5cnfnzc91kjqfhwdrc2d99n9mq-bootstrap-archive.drv.chroot/bin/sh - Invalid fstype: Invalid argument
`~~
  - ~~`error: builder for '/nix/store/*.drv' failed due to signal 11 (Segmentation fault)`~~
- ~~initialHashedPassword~~
  - Won't bother with this or putting ssh keys in sops for now. Neither of the VMs are directly exposed, on build01 (build box) it doesn't really matter if we allow everyone with ssh access to the machine to also have root in the VM and on build03 (CI) only the community admins have ssh access to the machine anyway.
- ~~telegraf: `ld-elf.so.1: Shared object "libthr.so.3" not found, required by "telegraf"`~~
- ~~increase disk size~~