### PR TITLE
dev/packages: pin cloudflare provider to v4

### DIFF
--- a/dev/packages.nix
+++ b/dev/packages.nix
@@ -61,4 +61,15 @@
     ];
     doCheck = false;
   };
+  terraform-providers = prev.terraform-providers // {
+    cloudflare = (prev.terraform-providers.cloudflare.override { rev = "v4.52.0"; }).overrideAttrs (_: {
+      src = final.fetchFromGitHub {
+        owner = "cloudflare";
+        repo = "terraform-provider-cloudflare";
+        rev = "v4.52.0";
+        hash = "sha256-rgXsROzfjtUw994JH8x+j/UNMyl7E9cZ+77Fczc3uB8=";
+      };
+      vendorHash = "sha256-RULgejA/RTDHhRJRiqlgckK4Ut3GLvIE081/i6gQTjI=";
+    });
+  };
 }


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

> https://github.com/cloudflare/terraform-provider-cloudflare/releases/tag/v5.0.0
> v5.x of this provider is a ground-up rewrite of the SDK, using code generation from our OpenAPI spec.

5.0.0 and 5.1.0 were basically broken, 5.2.0 still seems to have problems, would need to either drop and reimport most of the cloudflare config or perform similar steps on the terraform state file, for now I think pinning the provider to v4 is the easier option.