### PR TITLE
modules/nixos/monitoring/alert-rules: add rasdaemon

### DIFF
--- a/modules/nixos/monitoring/alert-rules.nix
+++ b/modules/nixos/monitoring/alert-rules.nix
@@ -39,6 +39,11 @@
 
         Load15.expr = lib.mkForce ''system_load15 / system_n_cpus{host!~"(build|darwin).*"} >= 2.0'';
 
+        RASDaemon = {
+          expr = ''{__name__=~"ras_.*"} != 0'';
+          annotations.description = "RAS daemon reports a non-zero value";
+        };
+
         MatrixHookNotRunning = {
           expr = ''systemd_units_active_code{name="matrix-hook.service", sub!="running"}'';
           annotations.description = "{{$labels.host}} should have a running {{$labels.name}}";


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

RAS has 17 different metrics, for now probably simplest to just check for non-zero values.


Closes https://github.com/nix-community/infra/issues/1619