### PR TITLE
use 2.25-maintenance branch for nix_2_25

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,6 +155,23 @@
         "type": "github"
       }
     },
+    "nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743493776,
+        "narHash": "sha256-DPqyLkUT8NrdB177VNLxI1fYr3+ipkyQdhHnr5cIgL8=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "38de6fbe3867d405820cbed17615523c2e00557d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.25-maintenance",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -312,6 +329,7 @@
         "hercules-ci-effects": "hercules-ci-effects",
         "hydra": "hydra",
         "lite-config": "lite-config",
+        "nix": "nix",
         "nix-darwin": "nix-darwin",
         "nix-index-database": "nix-index-database",
         "nixos-facter-modules": "nixos-facter-modules",

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,8 @@
     nix-darwin.url = "github:qowoz/nix-darwin/darwin-sudo";
     nix-index-database.inputs.nixpkgs.follows = "nixpkgs";
     nix-index-database.url = "github:nix-community/nix-index-database";
+    nix.flake = false;
+    nix.url = "github:NixOS/nix/2.25-maintenance";
     nixos-facter-modules.url = "github:nix-community/nixos-facter-modules";
     nixpkgs-update-github-releases.flake = false;
     nixpkgs-update-github-releases.url = "github:nix-community/nixpkgs-update-github-releases";

--- a/modules/nixos/cgroups.nix
+++ b/modules/nixos/cgroups.nix
@@ -1,10 +1,14 @@
 {
+  inputs,
   pkgs,
   ...
 }:
 {
   nix = {
-    package = pkgs.nixVersions.nix_2_25;
+    package = pkgs.nixVersions.nix_2_25.overrideAttrs (o: {
+      version = o.version + inputs.nix.shortRev;
+      src = inputs.nix;
+    });
 
     settings = {
       experimental-features = [


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Switching to the maintenance branch for various fixes not yet tagged, will look at switching to a newer version of nix once the nix packaging in nixpkgs for 25.05 is sorted.