### PR TITLE
darwin01: test auto-optimise-store

### DIFF
--- a/hosts/darwin01/default.nix
+++ b/hosts/darwin01/default.nix
@@ -1,4 +1,4 @@
-{ inputs, ... }:
+{ inputs, pkgs, ... }:
 
 {
   imports = [
@@ -17,4 +17,10 @@
   nix.settings.system-features = [ "big-parallel" ];
 
   system.stateVersion = 5;
+
+  # test auto-optimise-store fix
+  # https://gerrit.lix.systems/c/lix/+/2100
+  nix.package = pkgs.lix;
+  nix.optimise.automatic = false;
+  nix.settings.auto-optimise-store = pkgs.lib.mkForce true;
 }


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Seems 2.92.0 isn't recommended, will wait for 2.92.1 or 2.93.