### PR TITLE
use ssh for sops keys

### DIFF
--- a/dev/shell.nix
+++ b/dev/shell.nix
@@ -9,7 +9,6 @@
           python3.pkgs.deploykit
           python3.pkgs.invoke
           sops
-          ssh-to-age
           yq-go
         ];
       };

--- a/devdoc/onboarding.md
+++ b/devdoc/onboarding.md
@@ -2,9 +2,9 @@
 
 - Add them to the [list of administrators](../docs/administrators.md)
 
-- Add their user and ssh key to [users](../users) as member of the `trusted` and `wheel` groups.
+- Add their user and ssh key to [users](../users) as member of the `trusted` and `wheel` groups and run `inv update-sops-files`.
 
-- Add their age key to [sops.json](../sops.json) and run `inv update-sops-files`.
+  - Their age key could also be added to [sops.json](../sops.json) as an alternative to using an ssh key with sops.
 
 - Add their email in [terraform/locals.tf](../terraform/locals.tf), this will give them access to:
 

--- a/sops.json
+++ b/sops.json
@@ -5,15 +5,5 @@
     "ryantm": "age1d87z3zqlv6ullnzyng8l722xzxwqr677csacf3zf3l28dau7avfs6pc7ay",
     "zimbatm": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
     "zowoq": "age1m7xhem3qll35d539f364pm6txexvnp6k0tk34d8jxu4ry3pptv7smm0k5n"
-  },
-  "hosts": {
-    "build01": "age17jtyn2y4fpey6q7ers9gtnh4580xj89zdjuew9nqhxywmsaw94fs5udupc",
-    "build02": "age1kh6yvgxz9ys74as7aufdy8je7gmqjtguhnjuxvj79qdjswk2r3xqxf2n6d",
-    "build03": "age1qg7tfjwzp6dxwkw9vej6knkhdvqre3fu7ryzsdk5ggvtdx854ycqevlwnq",
-    "build04": "age1r464z5e2shvnh9ekzapgghevr9wy7spd4d7pt5a89ucdk6kr6yhqzv5gkj",
-    "build05": "age1kmz80s96paknelzqlz59ezctl7teejdvsm5f48f2udj5sp5m6qaszuauw7",
-    "darwin01": "age15dljvnazm0njdt7fh7drlsqnqx35766aex8zsv634zzpecu9cdgssmqv9a",
-    "darwin02": "age1xpzexnaulzdjtnwstvgvtq2ar7nkk2lj46u96ewjvtgt7g47jsxs0mhag3",
-    "web02": "age158v8dpppnw3yt2kqgqekwamaxpst5alfrnvvt7z36wfdk4veydrsqxc2tl"
   }
 }

--- a/sops.json
+++ b/sops.json
@@ -1,9 +1,5 @@
 {
   "admins": {
-    "adisbladis": "age1dzvjjum2p240qtdt2qcxpm7pl2s5w36mh4fs3q9dhhq0uezvdqaq9vrgfy",
-    "mic92": "age17n64ahe3wesh8l8lj0zylf4nljdmqn28hvqns2g7hgm9mdkhlsvsjuvkxz",
-    "ryantm": "age1d87z3zqlv6ullnzyng8l722xzxwqr677csacf3zf3l28dau7avfs6pc7ay",
-    "zimbatm": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
     "zowoq": "age1m7xhem3qll35d539f364pm6txexvnp6k0tk34d8jxu4ry3pptv7smm0k5n"
   }
 }

--- a/sops.nix
+++ b/sops.nix
@@ -3,6 +3,10 @@ let
   keys = builtins.fromJSON (builtins.readFile ./sops.json);
   admins = builtins.attrValues keys.admins;
 
+  hosts =
+    builtins.mapAttrs (_: v: v.publicKey)
+      (import ./modules/shared/known-hosts.nix).programs.ssh.knownHosts;
+
   mapAttrsToList = f: attrs: map (name: f name attrs.${name}) (builtins.attrNames attrs);
 
   renderPermissions =
@@ -22,7 +26,7 @@ let
       "secrets.yaml" = [ ];
       "terraform/secrets.yaml" = [ ];
     }
-    // builtins.mapAttrs (_: value: (map (x: keys.hosts.${x}) value)) {
+    // builtins.mapAttrs (_: value: (map (x: hosts.${x}) value)) {
       "modules/secrets/backup.yaml" = [
         "build02"
         "build03"
@@ -43,7 +47,7 @@ let
       mapAttrsToList (hostname: key: {
         name = "hosts/${hostname}/secrets.yaml";
         value = [ key ];
-      }) keys.hosts
+      }) hosts
     );
 in
 {

--- a/sops.nix
+++ b/sops.nix
@@ -1,7 +1,12 @@
 # https://github.com/TUM-DSE/doctor-cluster-config/blob/8c11c117e66af1cc205eb2094ab94e8a3317ff2e/sops.yaml.nix
 let
   keys = builtins.fromJSON (builtins.readFile ./sops.json);
-  admins = builtins.attrValues keys.admins;
+  admins = builtins.attrValues (
+    builtins.mapAttrs (
+      name: _: builtins.replaceStrings [ "\n" ] [ "" ] (builtins.readFile (./users/keys + "/${name}"))
+    ) (builtins.readDir ./users/keys)
+    // keys.admins
+  );
 
   hosts =
     builtins.mapAttrs (_: v: v.publicKey)

--- a/tasks.py
+++ b/tasks.py
@@ -85,7 +85,7 @@ def update_sops_files(c: Any) -> None:
 @task
 def print_keys(c: Any, flake_attr: str) -> None:
     """
-    Decrypt host private key, print ssh and age public keys. Use inv print-keys --flake-attr build01
+    Decrypt host private key, print ssh public key. Use inv print-keys --flake-attr build01
     """
     with TemporaryDirectory() as tmpdir:
         decrypt_host_key(flake_attr, tmpdir)
@@ -98,13 +98,6 @@ def print_keys(c: Any, flake_attr: str) -> None:
         )
         print("###### Public keys ######")
         print(pubkey.stdout)
-        print("###### Age keys ######")
-        subprocess.run(
-            ["ssh-to-age"],
-            input=pubkey.stdout,
-            check=True,
-            text=True,
-        )
 
 
 @task


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

~~Can't do the same for admins yet as currently I'm using `SOPS_AGE_KEY` and there isn't an equivalent for ssh, it only supports paths.~~

Can have both and have a check to ensure it is up to date.