### PR TITLE
dev/packages: pin prometheus

### DIFF
--- a/dev/packages.nix
+++ b/dev/packages.nix
@@ -14,6 +14,17 @@
       })
     ];
   });
+  prometheus = prev.prometheus.overrideAttrs (_: rec {
+    version = "3.1.0";
+    src = final.fetchFromGitHub {
+      owner = "prometheus";
+      repo = "prometheus";
+      tag = "v${version}";
+      hash = "sha256-Q3f0L6cRVQRL1AHgUI3VNbMG9eTfcApbXfSjOTHr7Go=";
+    };
+    vendorHash = "sha256-vQwBnSxoyIYTeWLk3GD9pKDuUjjsMfwPptgyVnzcTok=";
+    doCheck = false;
+  });
   sk-libfido2 = prev.openssh.overrideAttrs (o: {
     pname = "sk-libfido2";
     # rebase of https://github.com/openssh/openssh-portable/commit/ca0697a90e5720ba4d76cb0ae9d5572b5260a16c


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Seems something in 3.2 or 3.3 is changed or broken, this alert start firing for build05 but it is already disabled.

https://github.com/nix-community/infra/blob/b8130c72a8a66156867d3e3245225083a68c89ae/modules/nixos/monitoring/alert-rules.nix#L52