### PR TITLE
modules/nixos/hydra: create account for hexa

### DIFF
--- a/modules/nixos/hydra.nix
+++ b/modules/nixos/hydra.nix
@@ -110,6 +110,7 @@ in
           github;zimbatm@zimbatm.com;admin;;
           github;zowoq.gh@gmail.com;admin;;
           github;me@linj.tech;restart-jobs;;
+          hydra;hexa;restart-jobs;$argon2id$v=19$m=262144,t=3,p=1$U0JEc2FMT2NTYkJQY1VMMQ$JlHT6wBnwHfMDxNKWTEriQ;
         '';
       in
       ''


### PR DESCRIPTION
The comment says sha1, but hydra can deal with argon2id hashes just fine. Wondering what, if anything, creates that limitation.

The `hydra-create-user` script even has instructions how to generate such a hash.
```
Hydra uses Argon2id hashes, which can be generated like so:

    $ nix-shell -p libargon2
    [nix-shell]$ tr -d \\n | argon2 "$(LC_ALL=C tr -dc '[:alnum:]' < /dev/urandom | head -c16)" -id -t 3 -k 262144 -p 1 -l 16 -e
    foobar
    Ctrl^D
    $argon2id$v=19$m=262144,t=3,p=1$NFU1QXJRNnc4V1BhQ0NJQg$6GHqjqv5cNDDwZqrqUD0zQ
```

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
