### PR TITLE
modules/nixos/community-builder/users: allow wheel group

### DIFF
--- a/modules/darwin/community-builder/users.nix
+++ b/modules/darwin/community-builder/users.nix
@@ -256,6 +256,7 @@ let
       # lib.maintainers.emily, https://github.com/emilazy
       name = "emily";
       trusted = true;
+      # wheel = true; admin group set manually
       uid = 542;
       keys = ./keys/emily;
     }

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -392,7 +392,10 @@ in
       inherit (u) name;
       value = {
         isNormalUser = true;
-        extraGroups = if (u ? trusted && u.trusted) then [ "trusted" ] else [ ];
+        extraGroups = builtins.concatLists [
+          (if u ? trusted && u.trusted then [ "trusted" ] else [ ])
+          (if u ? wheel && u.wheel then [ "wheel" ] else [ ])
+        ];
         home = "/home/${u.name}";
         createHome = true;
         shell = u.shell or config.users.defaultUserShell;

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -276,6 +276,7 @@ let
       name = "emily";
       # lib.maintainers.emily, https://github.com/emilazy
       trusted = true;
+      wheel = true;
       keys = ./keys/emily;
     }
     {


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Currently the nix-community admins share the admin account on the darwin boxes, for now I'll just manage the sudo permissions manually for other users.
