### PR TITLE
remove x86_64-darwin

### DIFF
--- a/docs/community-builders.md
+++ b/docs/community-builders.md
@@ -12,7 +12,7 @@ build-box.nix-community.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIElIQ54qAy7Dh63r
 aarch64-build-box.nix-community.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG9uyfhyli+BRtk64y+niqtb+sKquRGGZ87f4YRc8EE1
 ```
 
-`aarch64-darwin`, `x86_64-darwin`
+`aarch64-darwin`
 
 ```text
 darwin-build-box.nix-community.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKMHhlcn7fUpUuiOFeIhDqBzBNFsbNqq+NpzuGX3e6zv

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -2,12 +2,11 @@ We provide CI for these platforms:
 
 - `aarch64-darwin`
 - `aarch64-linux`
-- `x86_64-darwin`
 - `x86_64-linux`
 
 Both `aarch64-linux` and `x86_64-linux` have support for `kvm`/`nixos-test`.
 
-We only have limited build capacity for `*-darwin` so please don't use it excessively.
+We only have limited build capacity for `aarch64-darwin` so please don't use it excessively.
 
 See [here](infrastructure.md#continuous-integration) for details about the hardware.
 

--- a/flake.lock
+++ b/flake.lock
@@ -494,15 +494,16 @@
     },
     "systems": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1774449309,
+        "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",
         "owner": "nix-systems",
         "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "rev": "c29398b59d2048c4ab79345812849c9bd15e9150",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
+        "ref": "future-26.11",
         "repo": "default",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -519,15 +519,16 @@
     },
     "systems": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1774449309,
+        "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",
         "owner": "nix-systems",
         "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "rev": "c29398b59d2048c4ab79345812849c9bd15e9150",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
+        "ref": "future-26.11",
         "repo": "default",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
     sops-nix.url = "github:qowoz/sops-nix/ssh"; # rebased https://github.com/Mic92/sops-nix/pull/779
     srvos.inputs.nixpkgs.follows = "nixpkgs";
     srvos.url = "github:nix-community/srvos";
-    systems.url = "github:nix-systems/default";
+    systems.url = "github:nix-systems/default/future-26.11";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     # keep-sorted end
@@ -90,7 +90,6 @@
         { lib, ... }:
         {
           nixpkgs = {
-            config.allowDeprecatedx86_64Darwin = true;
             overlays = [
               (final: prev: (import ./dev/packages.nix { inherit final prev inputs; }))
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
     sops-nix.url = "github:qowoz/sops-nix/ssh"; # rebased https://github.com/Mic92/sops-nix/pull/779
     srvos.inputs.nixpkgs.follows = "nixpkgs";
     srvos.url = "github:nix-community/srvos";
-    systems.url = "github:nix-systems/default";
+    systems.url = "github:nix-systems/default/future-26.11";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     # keep-sorted end
@@ -93,7 +93,6 @@
         { lib, ... }:
         {
           nixpkgs = {
-            config.allowDeprecatedx86_64Darwin = true;
             overlays = [
               (final: prev: (import ./dev/packages.nix { inherit final prev inputs; }))
             ];

--- a/hosts/darwin01/default.nix
+++ b/hosts/darwin01/default.nix
@@ -10,7 +10,6 @@
   nixCommunity.darwin.ipv6 = "2a01:4f8:d1:5716::2 64 2a01:4f8:d1:5716::1";
 
   nix.settings.sandbox = "relaxed";
-  nix.settings.extra-platforms = [ "x86_64-darwin" ];
 
   # disable nixos-tests
   nix.settings.system-features = [ "big-parallel" ];

--- a/hosts/darwin02/default.nix
+++ b/hosts/darwin02/default.nix
@@ -12,7 +12,6 @@
   nixCommunity.darwin.ipv6 = "2a01:4f8:d1:5715::2 64 2a01:4f8:d1:5715::1";
 
   nix.settings.sandbox = "relaxed";
-  nix.settings.extra-platforms = [ "x86_64-darwin" ];
 
   # disable nixos-tests
   nix.settings.system-features = [ "big-parallel" ];

--- a/modules/darwin/common/software-update.nix
+++ b/modules/darwin/common/software-update.nix
@@ -1,12 +1,4 @@
-{ lib, ... }:
 {
-  system.activationScripts.postActivation.text = lib.mkBefore ''
-    if ! pgrep -q oahd; then
-      echo installing rosetta... >&2
-      softwareupdate --install-rosetta --agree-to-license
-    fi
-  '';
-
   system.defaults.CustomSystemPreferences = {
     # check daily, install critical updates, disable macos updates
     "/Library/Preferences/com.apple.SoftwareUpdate" = {


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

> https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.05
> This will be the last release of Nixpkgs to support x86_64-darwin. Platform support will be maintained and binaries built until Nixpkgs 26.05 goes out of support at the end of 2026. For 26.11, due to Apple’s deprecation of the platform and limited build infrastructure and developer time, we will no longer build packages for x86_64-darwin or support building them from source.
