### PR TITLE
build02, modules/shared/ci-builder: limit cores

### DIFF
--- a/hosts/build02/default.nix
+++ b/hosts/build02/default.nix
@@ -1,4 +1,4 @@
-{ inputs, ... }:
+{ config, inputs, ... }:
 
 {
   imports = [
@@ -11,6 +11,7 @@
     inputs.srvos.nixosModules.hardware-hetzner-online-amd
   ];
 
+  nix.settings.cores = config.nix.settings.max-jobs / 2;
   nix.settings.max-jobs = 24;
 
   # set in srvos, remove when reinstalling

--- a/modules/shared/ci-builder.nix
+++ b/modules/shared/ci-builder.nix
@@ -1,4 +1,7 @@
+{ config, ... }:
 {
+  nix.settings.cores = config.nix.settings.max-jobs / 4;
+
   # match buildbot timeouts
   # https://github.com/nix-community/buildbot-nix/blob/85c0b246cc96cc244e4d9889a97c4991c4593dc3/buildbot_nix/__init__.py#L1008
 


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

OOMs and lockups are intermittent problems on these hosts, don't really want to limit max-jobs as I think may cause more problems and also can't really reduce max-jobs any more for hydra anyway. Will try this for a couple of weeks, I'm hoping it'll be an overall improvement.