### PR TITLE
modules/nixos/monitoring/alert-rules: silence vm reboot

### DIFF
--- a/modules/nixos/monitoring/alert-rules.nix
+++ b/modules/nixos/monitoring/alert-rules.nix
@@ -44,6 +44,8 @@
           annotations.description = "RAS daemon reports a non-zero value";
         };
 
+        Reboot.expr = lib.mkForce ''system_uptime{host!="nixbsd-freebsd"} < 300'';
+
         MatrixHookNotRunning = {
           expr = ''systemd_units_active_code{name="matrix-hook.service", sub!="running"}'';
           annotations.description = "{{$labels.host}} should have a running {{$labels.name}}";


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
