### PR TITLE
modules/nixos/monitoring/grafana: restrict to admins

### DIFF
--- a/modules/nixos/monitoring/grafana.nix
+++ b/modules/nixos/monitoring/grafana.nix
@@ -27,7 +27,7 @@
         allowed_organizations = [ "nix-community" ];
         role_attribute_strict = true;
         allow_assign_grafana_admin = true;
-        role_attribute_path = "contains(groups[*], '@nix-community/admin') && 'GrafanaAdmin' || 'Editor'";
+        role_attribute_path = "contains(groups[*], '@nix-community/admin') && 'GrafanaAdmin' || 'None'";
       };
 
       server = {


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

We're not currently using grafana for anything but now we adding org members in bulk I'll lock this down. If there is community interest in setting up dashboards for the infra I'll create another github team for that with editor permissions.