### PR TITLE
switch to hydra upstream package

### DIFF
--- a/dev/packages.nix
+++ b/dev/packages.nix
@@ -1,8 +1,14 @@
 {
   final,
+  inputs,
   ...
 }:
 {
+  hydra = final.callPackage (import "${inputs.hydra}/package.nix") {
+    inherit (final.lib) fileset;
+    nixComponents = final.nixVersions.nixComponents_2_29;
+    rawSrc = inputs.hydra;
+  };
   rfc39 = final.rustPlatform.buildRustPackage {
     pname = "rfc39";
     version = "0-unstable-2025-05-21";

--- a/flake.lock
+++ b/flake.lock
@@ -122,6 +122,22 @@
         "type": "github"
       }
     },
+    "hydra": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1754404514,
+        "narHash": "sha256-h8UNR3LVrD313iX1OazDwIcMLksh0p6oJv9msEfjS0E=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "79ba8fdd04ba53826aa9aaba6e25fd0d6952b3b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "hydra",
+        "type": "github"
+      }
+    },
     "lite-config": {
       "locked": {
         "lastModified": 1748349708,
@@ -392,6 +408,7 @@
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "hercules-ci-effects": "hercules-ci-effects",
+        "hydra": "hydra",
         "lite-config": "lite-config",
         "nix-darwin": "nix-darwin",
         "nix-index-database": "nix-index-database",

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,8 @@
     hercules-ci-effects.inputs.flake-parts.follows = "flake-parts";
     hercules-ci-effects.inputs.nixpkgs.follows = "nixpkgs";
     hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
+    hydra.flake = false;
+    hydra.url = "github:NixOS/hydra";
     lite-config.url = "github:yelite/lite-config";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
     nix-darwin.url = "github:nix-darwin/nix-darwin";


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->



Follow upstream for now while it is active and we're trying the new queue runner, will also allow us to get the security fixes as soon as they are released.

https://discourse.nixos.org/t/pre-disclosure-announcement-security-advisory-for-hydra-on-august-12-2025/67615