### PR TITLE
armv7l: Add also a proper system feature

### DIFF
--- a/modules/nixos/common/armv7l.nix
+++ b/modules/nixos/common/armv7l.nix
@@ -26,5 +26,6 @@
         ];
 
         nix.settings.extra-platforms = [ "armv7l-linux" ];
+        nix.settings.system-features = [ "gccarch-armv7-a" ];
       };
 }


### PR DESCRIPTION
Otherwise the following:

```
ssh aarch64-build-box.nix-community.org nix build nixpkgs#legacyPackages.armv7l-linux.hello
```

Fails with:

```
error: a 'armv7l-linux' with features {gccarch-armv7-a} is required to build '/nix/store/j7d3qk6a5s5lj7apn9pja6rhixahlnyr-bootstrap-stage0-glibc-bootstrapFiles.drv', but I am a 'aarch64-linux' with features {benchmark, big-parallel, gccarch-armv8-a, kvm, nixos-test, uid-range}
```
