### PR TITLE
modules/nixos/disko-zfs: add dataset for /tmp

### DIFF
--- a/modules/nixos/disko-zfs.nix
+++ b/modules/nixos/disko-zfs.nix
@@ -85,6 +85,12 @@
             mountpoint = "/";
             options.mountpoint = "legacy";
           };
+          tmp = {
+            type = "zfs_fs";
+            mountpoint = "/tmp";
+            options.mountpoint = "legacy";
+            options.sync = "disabled";
+          };
         };
       };
     };


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Won't reprovision the machines, I'll just create the dataset manually.

`zfs create -u -o sync=disabled -o mountpoint=legacy zroot/tmp`

cc @Mic92 