### PR TITLE
modules/nixos/buildbot: disable autofirma-nix

### DIFF
--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -8,7 +8,6 @@ let
   repoAllowlist = [
     # keep-sorted start case=no
     "nix-community/authentik-nix"
-    "nix-community/autofirma-nix"
     "nix-community/dream2nix"
     "nix-community/ethereum.nix"
     "nix-community/home-manager"


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

https://github.com/nix-community/autofirma-nix/pulls?q=is%3Apr+is%3Aclosed

Repo CI checks seem to be broken and auto update/merge are spamming buildbot with PRs. Repo looks like it hasn't been active for a few weeks.