### PR TITLE
remove x86_64-darwin CI

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -2,12 +2,11 @@ We provide CI for these platforms:
 
 - `aarch64-darwin`
 - `aarch64-linux`
-- `x86_64-darwin`
 - `x86_64-linux`
 
 Both `aarch64-linux` and `x86_64-linux` have support for `kvm`/`nixos-test`.
 
-We only have limited build capacity for `*-darwin` so please don't use it excessively.
+We only have limited build capacity for `aarch64-darwin` so please don't use it excessively.
 
 See [here](./infrastructure.md#continuous-integration) for details about the hardware.
 

--- a/hosts/darwin02/default.nix
+++ b/hosts/darwin02/default.nix
@@ -1,4 +1,4 @@
-{ inputs, ... }:
+{ inputs, lib, ... }:
 
 {
   imports = [
@@ -12,7 +12,7 @@
   nixCommunity.darwin.ipv6 = "2a01:4f8:d1:5715::2 64 2a01:4f8:d1:5715::1";
 
   nix.settings.sandbox = "relaxed";
-  nix.settings.extra-platforms = [ "x86_64-darwin" ];
+  nix.settings.extra-platforms = lib.mkForce [ ];
 
   # disable nixos-tests
   nix.settings.system-features = [ "big-parallel" ];


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Split from https://github.com/nix-community/infra/pull/1860.

Double our darwin CI capacity? 

I've already asked some repos to only use aarch64-darwin to reduce the load on darwin CI but it'd be easier to just outright disable it.

@Mic92 Are you fine with not having x86_64-darwin on the repos you maintain?