### PR TITLE
Revert "nixpkgs-update: pin nixpkgs-review"

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -24,17 +24,7 @@ let
 
     coreutils
     gist
-    # https://github.com/Mic92/nixpkgs-review/issues/446
-    (nixpkgs-review.overrideAttrs (_: {
-      name = "nixpkgs-review-2.12.0";
-      version = "2.12.0";
-      src = fetchFromGitHub {
-        owner = "Mic92";
-        repo = "nixpkgs-review";
-        tag = "2.12.0";
-        hash = "sha256-yNdBqL3tceuoUHx8/j2y5ZTq1zeVDAm37RZtlCbC6rg=";
-      };
-    }))
+    nixpkgs-review
     tree
   ];
 


### PR DESCRIPTION
This reverts commit b90a577268bc6382cf84c997cba8f94ec7c9451d.

seems to be fixed in 3.5.0

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
