### PR TITLE
modules/nixos/disko-zfs: add dataset for /nix/var/nix/builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756733629,
-        "narHash": "sha256-dwWGlDhcO5SMIvMSTB4mjQ5Pvo2vtxvpIknhVnSz2I8=",
+        "lastModified": 1757508292,
+        "narHash": "sha256-7lVWL5bC6xBIMWWDal41LlGAG+9u2zUorqo3QCUL4p4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a5c4f2ab72e3d1ab43e3e65aa421c6f2bd2e12a1",
+        "rev": "146f45bee02b8bd88812cfce6ffc0f933788875a",
         "type": "github"
       },
       "original": {
@@ -234,11 +234,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757130842,
-        "narHash": "sha256-4i7KKuXesSZGUv0cLPLfxbmF1S72Gf/3aSypgvVkwuA=",
+        "lastModified": 1757430124,
+        "narHash": "sha256-MhDltfXesGH8VkGv3hmJ1QEKl1ChTIj9wmGAFfWj/Wk=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "15f067638e2887c58c4b6ba1bdb65a0b61dc58c5",
+        "rev": "830b3f0b50045cf0bcfd4dab65fad05bf882e196",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756612744,
-        "narHash": "sha256-/glV6VAq8Va3ghIbmhET3S1dzkbZqicsk5h+FtvwiPE=",
+        "lastModified": 1757218147,
+        "narHash": "sha256-IwOwN70HvoBNB2ckaROxcaCvj5NudNc52taPsv5wtLk=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "3fe768e1f058961095b4a0d7a2ba15dc9736bdc6",
+        "rev": "9b144dc3ef6e42b888c4190e02746aab13b0e97f",
         "type": "github"
       },
       "original": {
@@ -328,10 +328,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757195359,
-        "narHash": "sha256-Uf/d5NGvq+Q6ct+n5xRr76N1ZGV0vkfsJ6iVTciPkY0=",
+        "lastModified": 1757493204,
+        "narHash": "sha256-bwg0O7Xo/T7aTWp0zicklTonSULI33Y1LMsqFBmTIf8=",
         "ref": "nixos-unstable-small",
-        "rev": "f4cefbe0160ba99567be386a043824549ccd5cb7",
+        "rev": "f9e9d45a64c8ff4e9906260804a1679a28819b4e",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756786509,
-        "narHash": "sha256-wNnMjVRyvilSeozfB06knXvEis8eANIxBBTp5QNT75A=",
+        "lastModified": 1757348252,
+        "narHash": "sha256-4Faogy9UkX4r3rQ6zSsVKsmnHlifR1Cpu8LPUp6VibY=",
         "owner": "nix-community",
         "repo": "nur-update",
-        "rev": "8b2758baa6393be724fdcd3022b8dc0df85367da",
+        "rev": "800e65b8d841e6e894c662139126a260581b1851",
         "type": "github"
       },
       "original": {
@@ -428,11 +428,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756096381,
-        "narHash": "sha256-Btuo4T6OestghwBlSMyFs39DMbRqL+iKl/7swgYn/w8=",
+        "lastModified": 1757309975,
+        "narHash": "sha256-kex6/Kce5UWOPA71VIjmoW4qrgYh5kaeWD4g1GfCt7s=",
         "owner": "mirkolenz",
         "repo": "quadlet-nix",
-        "rev": "9c23558dceac438a6ffb5c1e4d2e36bc76f97b3b",
+        "rev": "ae202377b275b0971b24b6a3062879fedc75e38c",
         "type": "github"
       },
       "original": {
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754988908,
-        "narHash": "sha256-t+voe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U=",
+        "lastModified": 1757503115,
+        "narHash": "sha256-S9F6bHUBh+CFEUalv/qxNImRapCxvSnOzWBUZgK1zDU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3223c7a92724b5d804e9988c6b447a0d09017d48",
+        "rev": "0bf793823386187dff101ee2a9d4ed26de8bbf8c",
         "type": "github"
       },
       "original": {
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756947399,
-        "narHash": "sha256-BP+tghzkQpt5NDcPhUsRjZtPd53jsubSNlmtWJclQZ8=",
+        "lastModified": 1757298062,
+        "narHash": "sha256-bSaQxOCzj0ky6HYSCJxoT8XEeqwzzJFP6R80bgGJVjM=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "27067044062111dfb077e735ee8641f05acaf4dc",
+        "rev": "0070590bf5bd5dc97b8e644720c3c7c90e16f8bc",
         "type": "github"
       },
       "original": {

--- a/modules/darwin/common/default.nix
+++ b/modules/darwin/common/default.nix
@@ -32,6 +32,17 @@
     HostKey /etc/ssh/ssh_host_ed25519_key
   '';
 
+  launchd.daemons.nix-build-cleanup = {
+    script = "${pkgs.findutils}/bin/find /nix/var/nix/builds -delete || true";
+    serviceConfig = {
+      KeepAlive = false;
+      LaunchOnlyOnce = true;
+      RunAtLoad = true;
+      StandardErrorPath = "/var/log/nix-build-cleanup.log";
+      StandardOutPath = "/var/log/nix-build-cleanup.log";
+    };
+  };
+
   system.activationScripts.postActivation.text = ''
     echo disabling spotlight indexing... >&2
     mdutil -a -i off -d &> /dev/null

--- a/modules/nixos/common/default.nix
+++ b/modules/nixos/common/default.nix
@@ -35,6 +35,8 @@
   zramSwap.enable = true;
   zramSwap.memoryPercent = 100;
 
+  systemd.tmpfiles.rules = [ "D! /nix/var/nix/builds 0755 root root" ];
+
   systemd.services.sysctl-after-boot = {
     serviceConfig.Restart = "on-failure";
     serviceConfig.Type = "oneshot";

--- a/modules/nixos/disko-zfs.nix
+++ b/modules/nixos/disko-zfs.nix
@@ -85,6 +85,12 @@
             mountpoint = "/";
             options.mountpoint = "legacy";
           };
+          build = {
+            type = "zfs_fs";
+            mountpoint = "/nix/var/nix/builds";
+            options.mountpoint = "legacy";
+            options.sync = "disabled";
+          };
           tmp = {
             type = "zfs_fs";
             mountpoint = "/tmp";


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Did this for /tmp in https://github.com/nix-community/infra/pull/1942.

Won't reprovision the machines, I'll just create the dataset manually.

`zfs create -u -o sync=disabled -o mountpoint=legacy zroot/build`

cc @Mic92