### PR TITLE
disable bsd VMs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -141,11 +141,6 @@
                   self.darwinConfigurations // self.nixosConfigurations
                 )
               )
-          //
-            lib.mapAttrs' (name: config: lib.nameValuePair "host-${name}" config.config.system.build.toplevel)
-              (
-                (lib.filterAttrs (_: config: config.pkgs.buildPlatform.system == system)) self.nixbsdConfigurations
-              )
           // pkgs.lib.optionalAttrs (system == "x86_64-linux") (
             {
               inherit (self'.packages)

--- a/hosts/build01/default.nix
+++ b/hosts/build01/default.nix
@@ -3,7 +3,6 @@
   imports = [
     inputs.self.nixosModules.cgroups
     inputs.self.nixosModules.community-builder
-    inputs.self.nixosModules.freebsd-builder
     inputs.self.nixosModules.disko-zfs
     inputs.srvos.nixosModules.hardware-hetzner-online-amd
   ];

--- a/hosts/build03/default.nix
+++ b/hosts/build03/default.nix
@@ -10,7 +10,6 @@
     inputs.self.nixosModules.cgroups
     inputs.self.nixosModules.ci-builder
     inputs.self.nixosModules.disko-zfs
-    inputs.self.nixosModules.freebsd-builder
     inputs.self.nixosModules.github-org-backup
     inputs.self.nixosModules.hercules-ci
     inputs.self.nixosModules.hydra

--- a/modules/nixos/hydra.nix
+++ b/modules/nixos/hydra.nix
@@ -39,12 +39,6 @@
     hydra-send-stats.enable = false;
   };
 
-  environment.etc."nix/hydra/machines".source =
-    pkgs.runCommand "machines" { machines = config.environment.etc."nix/machines".text; }
-      ''
-        printf "$machines" | grep -e bsd > $out
-      '';
-
   services.hydra = {
     enable = true;
     buildMachinesFiles = [

--- a/modules/nixos/monitoring/prometheus.nix
+++ b/modules/nixos/monitoring/prometheus.nix
@@ -27,12 +27,9 @@
           in
           [
             {
-              targets =
-                builtins.concatMap (host: map (name: "${name}:9273") host.hostNames) (builtins.attrValues hosts)
-                ++ [
-                  "build01.nix-community.org:39273" # build01-freebsd
-                  "build03.nix-community.org:39273" # build03-freebsd
-                ];
+              targets = builtins.concatMap (host: map (name: "${name}:9273") host.hostNames) (
+                builtins.attrValues hosts
+              );
               labels.org = "nix-community";
             }
           ];


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

@rhelmot I've seen you comment that you have other commitments and won't be working on this for a while. The freebsd stdenv in nixpkgs has been broken for a while now, I've looked at fixing it but really requires someone with more knowledge of bsd and stdenv to fix it and keep it working. For now I'm going to disable the bsd VMs and the native CI jobs but I'll leave cross jobset for the nixbsd flake enabled. I'm happy to re-enable it for you or anyone else that will make use of it.

