### PR TITLE
web02: add vaultwarden

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -160,6 +160,7 @@
                 ;
               buildbot-nix = inputs'.buildbot-nix.checks.poller;
               quadlet-nix = inputs'.quadlet-nix.checks.nixos;
+              vaultwarden = pkgs.nixosTests.vaultwarden.sqlite;
             }
           );
         };

--- a/hosts/web02/default.nix
+++ b/hosts/web02/default.nix
@@ -4,6 +4,7 @@
     ./gandi.nix
     ./postgresql.nix
     ./postgresql-tf.nix
+    ./vaultwarden.nix
     inputs.self.nixosModules.monitoring
     inputs.self.nixosModules.nginx
   ];

--- a/hosts/web02/secrets.yaml
+++ b/hosts/web02/secrets.yaml
@@ -1,11 +1,8 @@
 grafana-client-secret: ENC[AES256_GCM,data:GRuUZDMzzCD+iB/r4fCLG4hkWzLGrKqokm2hpMerV1X6Dn4e2PzVcQ==,iv:X7f+hLCo/cLUBRH2Yilgn5PwzN//RmIfBaVcL6US6Mg=,tag:CdUB4mXMnTBwVM7I38mfrA==,type:str]
 nix-community-matrix-bot-token: ENC[AES256_GCM,data:rUi+deMQLcD0LnzpZqeezdbtwZNhHwUWMv5KlEBfWcWqJ3cZIV66G6L5MJ7v4b0r7OKrVSpQDinb+UXALO975OMr9L6EvO4Lx1RMxA==,iv:7ljmHi+P9cVVyJhpqyVvaAVy4ledqYFuqjX71J8fCk8=,tag:dAX+cJZbZ+1T9OHT57wxhA==,type:str]
 oauth2-proxy-key-file: ENC[AES256_GCM,data:HaW/nIfUdrilacO9JzsEvOA+pxZ4RKxJUN8jHSEyy50g8//RRpflR+fLXZoaAOV9hE7ztWa39EqTxGAi0AKWUCrS0v72NfI+WVfsdEOifQrkPFh67fRlD7xTDDVB6hmP4JczIpu+3kGJhZm5KuQ7bNeaf6PJF1QKQ+gXYeXR3NAszfoObRq+SYR4CmA=,iv:HELIcLH/2+ve5xT3VDXClVwGHMSyLmVfJcZ/RWD/x64=,tag:5NiDA1vketWZjE5NlaQE+A==,type:str]
+vaultwarden-env-file: ""
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
         - recipient: age158v8dpppnw3yt2kqgqekwamaxpst5alfrnvvt7z36wfdk4veydrsqxc2tl
           enc: |
@@ -61,8 +58,7 @@ sops:
             WWJIQnJVMVBoTkloL2UvY1AzcDNoSEkKiio0jhLaWW3SEkw9w9eYAVtA7BuyZcVd
             qkvuzeNejKmoUatQctNI2dOhH0uMySIcodKVsPksHJhZ/xloYO+mjg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-12-19T00:50:17Z"
-    mac: ENC[AES256_GCM,data:SAoTmNYsrFjyu/z2I75WIHtSv4KSA3OMBaw8CwmW+vpUbLx9chHiJlO4j4XRD50iddDu3LLtXDtSWq3ESiUVlpmOXLnhiIpMGptZjYJmLqT4D4B4pMcjOixUG/At/nkuY/3qaVhqan5f/mX6lwsJJAswNpVe8OeEw7NNUW9BQVA=,iv:SdX2bp7cyIQ+rhLIexeK6SzbyDnuQXrjBai5gFW8qMw=,tag:yn6mi65mbXBnza1NgZSx1w==,type:str]
-    pgp: []
+    lastmodified: "2025-09-15T07:20:53Z"
+    mac: ENC[AES256_GCM,data:crjFiYQkg1RWGVsnJZvalZr5s7JjbwGsxgoWDaQ3b2WPmDgQv34sn22N3hSuc212jdwkWQJyscIgMRJi2M1XTueVmhKMnb/qsLW4T9rUKLVdPbzzIAUXOvoD5ti9/VLOhyTDlEhh5E8Amv+rO770hMOjk9f4kdL9MiytjZCCwqE=,iv:kcRhmlHOzdagLnUcsIQZczAcqPkeLlOw4DgEKT6zlWk=,tag:IeX3EmEg13pwU3Vs9EeU7A==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.9.2
+    version: 3.10.2

--- a/hosts/web02/vaultwarden.nix
+++ b/hosts/web02/vaultwarden.nix
@@ -1,0 +1,21 @@
+{ config, ... }:
+{
+  sops.secrets.vaultwarden-env-file = { };
+
+  services.vaultwarden = {
+    enable = true;
+    dbBackend = "sqlite";
+    environmentFile = config.sops.secrets.vaultwarden-env-file.path;
+    config = {
+      DOMAIN = "https://vaultwarden.nix-community.org";
+      SIGNUPS_ALLOWED = false;
+      ROCKET_LOG = "critical";
+      ROCKET_ADDRESS = "127.0.0.1";
+      ROCKET_PORT = 8222;
+    };
+  };
+
+  services.nginx.virtualHosts."vaultwarden.nix-community.org" = {
+    locations."/".proxyPass = "http://localhost:8222";
+  };
+}


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Looking using ~~https://github.com/timewave-computer/sopsidy~~ or https://github.com/ritiek/sops-shell and moving all of the secrets to vaultwarden.

https://github.com/dani-garcia/vaultwarden/releases/tag/1.35.0
https://github.com/dani-garcia/vaultwarden/wiki/Enabling-SSO-support-using-OpenId-Connect

~~Vaultwarden recently merged SSO, I'll wait for it to land in a release before doing any work on this.~~

Just using the sqlite backend for dev, will switch to postgresql with hourly backups for prod.