### PR TITLE
remove cuda

### DIFF
--- a/docs/package-sets.md
+++ b/docs/package-sets.md
@@ -1,21 +1,3 @@
-#### Nixpkgs CUDA and ROCm
-
-See the [CUDA section of the nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#cuda) for more information.
-
-[CUDA and ROCm release set in nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/release-cuda.nix)
-
-Built on `nixos-unstable-small` for `x86_64-linux`:
-
-- [https://hydra.nix-community.org/jobset/nixpkgs/cuda](https://hydra.nix-community.org/jobset/nixpkgs/cuda)
-
-Built on `nixos-unstable-small` for `x86_64-linux`:
-
-- [https://hydra.nix-community.org/jobset/nixpkgs/rocm](https://hydra.nix-community.org/jobset/nixpkgs/rocm)
-
-Built on `nixos-$RELEASE-small` for `x86_64-linux`:
-
-- [https://hydra.nix-community.org/jobset/nixpkgs/cuda-stable](https://hydra.nix-community.org/jobset/nixpkgs/cuda-stable)
-
 #### Nixpkgs unfree redistributable
 
 [unfree redistributable release set in nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/release-unfree-redistributable.nix)

--- a/terraform/hydra-nixpkgs.tf
+++ b/terraform/hydra-nixpkgs.tf
@@ -30,15 +30,6 @@ locals {
       supported_systems = ["x86_64-freebsd"]
       release_source    = "https://github.com/nix-community/infra.git master"
     }
-    cuda = {
-      name              = "cuda"
-      description       = "nixos-unstable-small cuda"
-      nixpkgs_channel   = "https://github.com/NixOS/nixpkgs.git nixos-unstable-small"
-      release_file      = "pkgs/top-level/release-cuda.nix"
-      check_interval    = 1800
-      scheduling_shares = 6000
-      supported_systems = ["x86_64-linux"]
-    }
     cuda_stable = {
       name              = "cuda-stable"
       description       = "nixos-25.05-small cuda"
@@ -47,25 +38,6 @@ locals {
       check_interval    = 1800
       scheduling_shares = 6000
       supported_systems = ["x86_64-linux"]
-    }
-    cuda_stable_previous = {
-      name              = "cuda-stable-previous"
-      description       = "nixos-24.11-small cuda"
-      nixpkgs_channel   = "https://github.com/NixOS/nixpkgs.git nixos-24.11-small"
-      release_file      = "pkgs/top-level/release-cuda.nix"
-      check_interval    = 1800
-      scheduling_shares = 6000
-      supported_systems = ["x86_64-linux"]
-    }
-    rocm = {
-      name              = "rocm"
-      description       = "nixos-unstable-small rocm"
-      nixpkgs_channel   = "https://github.com/NixOS/nixpkgs.git nixos-unstable-small"
-      release_file      = "pkgs/top-level/release-cuda.nix"
-      check_interval    = 1800
-      scheduling_shares = 6000
-      supported_systems = ["x86_64-linux"]
-      variant           = "rocm"
     }
     unfree_redist = {
       name              = "unfree-redist"
@@ -146,17 +118,6 @@ resource "hydra_jobset" "nixpkgs_jobset" {
     content {
       name              = "full"
       type              = "boolean"
-      value             = input.value
-      notify_committers = false
-    }
-  }
-
-  dynamic "input" {
-    for_each = lookup(each.value, "variant", null) != null ? [each.value.variant] : []
-
-    content {
-      name              = "variant"
-      type              = "string"
       value             = input.value
       notify_committers = false
     }


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

I'll keep cuda-stable around until 25.05 is eol but won't bother with having it listed in our docs, not much point in advertising it.