### PR TITLE
terraform/hydra-nixpkgs: remove cuda-stable

### DIFF
--- a/terraform/hydra-nixpkgs.tf
+++ b/terraform/hydra-nixpkgs.tf
@@ -33,15 +33,6 @@ locals {
       supported_systems = ["x86_64-freebsd"]
       release_source    = "https://github.com/nix-community/infra.git master"
     }
-    cuda_stable = {
-      name              = "cuda-stable"
-      description       = "nixos-25.05-small cuda"
-      nixpkgs_channel   = "https://github.com/NixOS/nixpkgs.git nixos-25.05-small"
-      release_file      = "pkgs/top-level/release-cuda.nix"
-      check_interval    = 1800
-      scheduling_shares = 6000
-      supported_systems = ["x86_64-linux"]
-    }
     unfree_redist = {
       name              = "unfree-redist"
       description       = "nixos-unstable-small unfree+redistributable"


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Follow from https://github.com/nix-community/infra/pull/1978, will remove cuda-stable once 25.05 is eol.

https://github.com/NixOS/infra/commit/cfa5982b9961fccd252ff550213a0eb00c77f6f8