### PR TITLE
modules/nixos/buildbot: disable cacheFailedBuilds

### DIFF
--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -75,7 +75,7 @@ in
     showTrace = true;
     evalMaxMemorySize = 4096;
     evalWorkerCount = 32;
-    cacheFailedBuilds = true;
+    cacheFailedBuilds = false;
     workersFile = config.sops.templates.buildbot-nix-workers.path;
     cachix = {
       enable = true;


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Workaround for https://github.com/nix-community/buildbot-nix/issues/523.