### PR TITLE
modules/nixos/buildbot: add stylix

### DIFF
--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -29,6 +29,7 @@ let
     "nix-community/nixpkgs-xr"
     "nix-community/nixvim"
     "nix-community/srvos"
+    "nix-community/stylix"
     # keep-sorted end
   ];
 


### PR DESCRIPTION
See https://github.com/nix-community/stylix/pull/1961.

In short, there isn't enough disk space on a standard GitHub Actions runner to build all of our checks, especially when starting from an empty cache. This is because each testbed depends on the application it's theming, some of which are quite large. We also can't use a separate runner for each check because there are more checks than the maximum number of parallel jobs.

How much local disk space does BuildBot have? Cache space shouldn't be an issue because most of our dependencies are already on <https://cache.nixos.org>, so wouldn't need to be uploaded to Cachix.