### PR TITLE
modules/queue-runner: resolve pkgs.lib.recurseIntoAttrs alias warning

### DIFF
--- a/modules/queue-runner/hydra-queue-builder-v2.nix
+++ b/modules/queue-runner/hydra-queue-builder-v2.nix
@@ -135,7 +135,7 @@ in
 
       package = lib.mkOption {
         type = lib.types.package;
-        default = (pkgs.lib.recurseIntoAttrs (pkgs.callPackage ./package.nix { inherit inputs; })).builder;
+        default = (lib.recurseIntoAttrs (pkgs.callPackage ./package.nix { inherit inputs; })).builder;
       };
     };
   };

--- a/modules/queue-runner/hydra-queue-runner-v2.nix
+++ b/modules/queue-runner/hydra-queue-runner-v2.nix
@@ -187,7 +187,7 @@ in
       };
       package = lib.mkOption {
         type = lib.types.package;
-        default = (pkgs.lib.recurseIntoAttrs (pkgs.callPackage ./package.nix { inherit inputs; })).runner;
+        default = (lib.recurseIntoAttrs (pkgs.callPackage ./package.nix { inherit inputs; })).runner;
       };
     };
   };


### PR DESCRIPTION
```
Resolve the pkgs.lib.recurseIntoAttrs alias warning, following upstream
commit [1] ("all-packages: do not export lib functions from pkgs").

[1]: https://github.com/NixOS/nixpkgs/commit/03bb7d81954de1161110e4b8da50bd7e14f3b17e

Fixes: 16b3ba880f0b ("queue runner: fix aliases")
```

This warning is visible at https://buildbot.nix-community.org/api/v2/logs/1731399/raw_inline.
