### PR TITLE
nixos/community-builder: add magnetophon

### DIFF
--- a/modules/nixos/community-builder/keys/magnetophon
+++ b/modules/nixos/community-builder/keys/magnetophon
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGastoG2Cx4Zru3fHriMzNunJbenXe5MlFeSeA1lPuGG bart@magnetophon.nl

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -441,6 +441,13 @@ let
       shell = pkgs.zsh;
       keys = ./keys/mdaniels5757;
     }
+    {
+      # lib.maintainers.magnetophon, https://github.com/magnetophon
+      name = "magnetophon";
+      trusted = true;
+      shell = pkgs.fish;
+      keys = ./keys/magnetophon;
+    }
   ];
 in
 {


### PR DESCRIPTION
I maintain more than 120 packages and a few modules.
Sometimes nixpkgs-review-gha doesn't work, and I'd love to have an alternative method to test on mac.

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
