### PR TITLE
modules/nixos/buildbot.nix: Add `bun2nix`

### DIFF
--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -8,6 +8,7 @@ let
   repoAllowlist = [
     # keep-sorted start case=no
     "nix-community/authentik-nix"
+    "nix-community/bun2nix"
     "nix-community/dream2nix"
     "nix-community/ethereum.nix"
     "nix-community/home-manager"


### PR DESCRIPTION
Adds `bun2nix` to the allowed repos for buildbot - I wish to run CI on external pull requests for validation before I merge them into the master branch.

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
