### PR TITLE
terraform: switch to ephemeral for sops secrets

### DIFF
--- a/terraform/terraform_providers.tf
+++ b/terraform/terraform_providers.tf
@@ -12,7 +12,7 @@ terraform {
   }
 }
 
-data "sops_file" "nix-community" {
+ephemeral "sops_file" "nix-community" {
   source_file = "secrets.yaml"
 }
 
@@ -23,6 +23,6 @@ provider "github" {
 
 provider "hydra" {
   host     = "https://hydra.nix-community.org"
-  password = data.sops_file.nix-community.data["HYDRA_PASSWORD"]
+  password = ephemeral.sops_file.nix-community.data["HYDRA_PASSWORD"]
   username = "admin"
 }


### PR DESCRIPTION
prevents the secrets from being written to the tf state

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
