### PR TITLE
add disko-zfs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -50,6 +50,32 @@
         "type": "github"
       }
     },
+    "disko-zfs": {
+      "inputs": {
+        "disko": [
+          "disko"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773422739,
+        "narHash": "sha256-nfl7tj3TN8MZI5JpidUjlqax+2ly2BHay3tpM/cc9ik=",
+        "owner": "numtide",
+        "repo": "disko-zfs",
+        "rev": "adaef72fba88b4f313fcb3f7cf02e24b2a09b648",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "disko-zfs",
+        "type": "github"
+      }
+    },
     "empty": {
       "locked": {
         "lastModified": 1708697125,
@@ -435,6 +461,7 @@
       "inputs": {
         "buildbot-nix": "buildbot-nix",
         "disko": "disko",
+        "disko-zfs": "disko-zfs",
         "empty": "empty",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,10 @@
     buildbot-nix.inputs.nixpkgs.follows = "nixpkgs";
     buildbot-nix.inputs.treefmt-nix.follows = "treefmt-nix";
     buildbot-nix.url = "github:qowoz/buildbot-nix/infra";
+    disko-zfs.inputs.disko.follows = "disko";
+    disko-zfs.inputs.flake-parts.follows = "flake-parts";
+    disko-zfs.inputs.nixpkgs.follows = "nixpkgs";
+    disko-zfs.url = "github:numtide/disko-zfs";
     disko.inputs.nixpkgs.follows = "nixpkgs";
     disko.url = "github:nix-community/disko";
     empty.url = "github:nix-systems/empty";

--- a/modules/nixos/disko-zfs-systemd-boot.nix
+++ b/modules/nixos/disko-zfs-systemd-boot.nix
@@ -28,7 +28,17 @@ let
   };
 in
 {
-  imports = [ inputs.disko.nixosModules.disko ];
+  imports = [
+    inputs.disko.nixosModules.disko
+    inputs.disko-zfs.nixosModules.default
+  ];
+
+  disko.zfs = {
+    enable = true;
+    settings.ignoredProperties = [
+      "nixos:shutdown-time"
+    ];
+  };
 
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

https://discourse.nixos.org/t/disko-zfs-manage-your-datasets-declaratively/74624

```
# Additive Commands
> zfs set acltype=posixacl zroot
> zfs inherit nixos:shutdown-time zroot
# !! Destructive Commands !!
```

Currently our zfs config is fairly simple and doesn't change often so this isn't really useful at the moment.