### PR TITLE
modules/nixos/common: add extra-sandbox-paths for container nixosTests

### DIFF
--- a/modules/nixos/common/cgroups.nix
+++ b/modules/nixos/common/cgroups.nix
@@ -11,6 +11,9 @@
 
       auto-allocate-uids = true;
       use-cgroups = true;
+
+      # for networking between containers and VMs in nixosTests
+      extra-sandbox-paths = [ "/dev/net" ];
     };
   };
 }


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

I'll wait for nixos infra to decide if this is going to be enabled for hydra.nixos.org. We could have this on the build boxes without really making their security any worse but not much point in enabling it for build boxes or CI if it isn't enabled for h.n.o.