### PR TITLE
nix-daemon: vendor pending nix security fixes

### DIFF
--- a/modules/shared/nix-daemon.nix
+++ b/modules/shared/nix-daemon.nix
@@ -9,6 +9,8 @@ let
   asGB = size: toString (size * 1024 * 1024 * 1024);
 in
 {
+  imports = [ ./nix-security ];
+
   nix = {
     settings.trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="

--- a/modules/shared/nix-security/default.nix
+++ b/modules/shared/nix-security/default.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }:
+{
+  # Vendored fixes for two FOD-related nix vulnerabilities still in
+  # upstream review:
+  #
+  #   - GHSA-g3g9-5vj6-r3gj: std::filesystem::copy_file follows symlinks
+  #     when copying FOD outputs, allowing a malicious builder to overwrite
+  #     files outside the build sandbox.
+  #   - CVE-2025-46416: cooperating builders can smuggle file descriptors
+  #     via abstract unix sockets; mitigated via landlock
+  #     LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET on kernels >= 6.12.
+  #
+  # Patches are backported from https://git.ntd.one/nix-security/nix
+  # against the 2.31.3 tag that nixpkgs pins. Override only nix.package so
+  # we don't perturb the rest of pkgs; drop this module once the fixes land
+  # upstream.
+  nix.package =
+    (pkgs.nixVersions.nixComponents_2_31.appendPatches [
+      ./patches/ghsa-g3g9-5vj6-r3gj-2.31.patch
+      ./patches/CVE-2025-46416-2.31.patch
+    ]).nix-everything;
+}

--- a/modules/shared/nix-security/patches/CVE-2025-46416-2.31.patch
+++ b/modules/shared/nix-security/patches/CVE-2025-46416-2.31.patch
@@ -1,0 +1,232 @@
+From b743f908b10aa56b88fb490de8a0d893bd2d83d5 Mon Sep 17 00:00:00 2001
+From: Sergei Zimmerman <sergei@zimmerman.foo>
+Date: Sun, 5 Apr 2026 16:39:58 +0300
+Subject: [PATCH] libstore: Use landlock with
+ LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET for new enough kernels
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This partially fixes the issue with cooperating processes being able
+to communicate via abstract sockets. The fix is partial, because processes
+outside the landlock domain of the sandboxed process can still connect to
+a socket created by the FOD. There's no equivalent way of restricting inbound
+connections. This closes the gap when there's no cooperating process on the host
+(i.e. 2 separate FODs).
+
+>= 6.12 kernel is widespread enough (NixOS 25.11 ships it by
+default) that we have no reason not to apply this hardening, even though
+it's incomplete.
+
+ca-fd-leak test exercises this exact code path and now the smuggling
+process fails with (on new enough kernels that have landlock support enabled):
+
+vm-test-run-ca-fd-leak> machine # sandbox setup: applied landlock sandboxing
+vm-test-run-ca-fd-leak> machine # building '/nix/store/s7brgi6pdr5f3n8yqlgmdlz8blb89njc-smuggled.drv'...
+vm-test-run-ca-fd-leak> machine # building derivation '/nix/store/s7brgi6pdr5f3n8yqlgmdlz8blb89njc-smuggled.drv': woken up
+vm-test-run-ca-fd-leak> machine # connect: Operation not permitted
+vm-test-run-ca-fd-leak> machine # sendmsg: Socket not connected
+
+(cherry picked from commit 44017ca497c8b44d5dac179f5afc63e91fe45ed6)
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ src/libstore/meson.build                      |   5 +
+ .../unix/build/linux-derivation-builder.cc    | 103 ++++++++++++++++++
+ tests/nixos/ca-fd-leak/default.nix            |   8 +-
+ 3 files changed, 114 insertions(+), 2 deletions(-)
+
+diff --git a/src/libstore/meson.build b/src/libstore/meson.build
+index a275f4edc..dc8a7a940 100644
+--- a/src/libstore/meson.build
++++ b/src/libstore/meson.build
+@@ -77,6 +77,11 @@ foreach funcspec : check_funcs
+   configdata_priv.set(define_name, define_value)
+ endforeach
+ 
++if host_machine.system() == 'linux'
++  has_landlock = cxx.has_header('linux/landlock.h')
++  configdata_priv.set('HAVE_LANDLOCK', has_landlock.to_int())
++endif
++
+ has_acl_support = cxx.has_header('sys/xattr.h') \
+   and cxx.has_function('llistxattr') \
+   and cxx.has_function('lremovexattr')
+diff --git a/src/libstore/unix/build/linux-derivation-builder.cc b/src/libstore/unix/build/linux-derivation-builder.cc
+index eaac2bc28..dc5abf808 100644
+--- a/src/libstore/unix/build/linux-derivation-builder.cc
++++ b/src/libstore/unix/build/linux-derivation-builder.cc
+@@ -1,10 +1,16 @@
+ #ifdef __linux__
+ 
++#  include "store-config-private.hh"
++
+ #  include "nix/store/personality.hh"
+ #  include "nix/util/cgroup.hh"
+ #  include "nix/util/linux-namespaces.hh"
+ #  include "linux/fchmodat2-compat.hh"
+ 
++#  include <algorithm>
++#  include <string_view>
++#  include <cstdint>
++
+ #  include <sys/ioctl.h>
+ #  include <net/if.h>
+ #  include <netinet/ip.h>
+@@ -13,11 +19,16 @@
+ #  include <sys/param.h>
+ #  include <sys/mount.h>
+ #  include <sys/syscall.h>
++#  include <sys/prctl.h>
+ 
+ #  if HAVE_SECCOMP
+ #    include <seccomp.h>
+ #  endif
+ 
++#  if HAVE_LANDLOCK
++#    include <linux/landlock.h>
++#  endif
++
+ #  define pivot_root(new_root, put_old) (syscall(SYS_pivot_root, new_root, put_old))
+ 
+ namespace nix {
+@@ -121,6 +132,77 @@ static void setupSeccomp()
+ #  endif
+ }
+ 
++#  if HAVE_LANDLOCK && defined(LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET)
++
++#    define DO_LANDLOCK 1
++
++/* We are using LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET on best-effort basis. There are no glibc wrappers for now. */
++
++static int landlockCreateRuleset(const ::landlock_ruleset_attr * attr, std::size_t size, std::uint32_t flags)
++{
++    return ::syscall(__NR_landlock_create_ruleset, attr, size, flags);
++}
++
++static int landlockRestrictSelf(Descriptor rulesetFd, std::uint32_t flags)
++{
++    return ::syscall(__NR_landlock_restrict_self, rulesetFd, flags);
++}
++
++static int getLandlockAbiVersion()
++{
++    int abiVersion = landlockCreateRuleset(nullptr, 0, LANDLOCK_CREATE_RULESET_VERSION);
++    return abiVersion;
++}
++
++static void setupLandlock()
++{
++    bool landlockSupportsScopeAbstractUnixSocket = []() {
++        int abiVersion = getLandlockAbiVersion();
++        if (abiVersion >= 6)
++            /* All good, we can use LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET. See
++               https://docs.kernel.org/userspace-api/landlock.html#abstract-unix-socket-abi-6 */
++            return true;
++
++        if (abiVersion == -1) {
++            debug("landlock is not available");
++            return false;
++        }
++
++        debug("landlock version %d does not support LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET", abiVersion);
++        return false;
++    }();
++
++    /* Bail out early if landlock is not enabled or LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET wouldn't work.
++       TODO: Consider adding more landlock rules for filesystem access as defense-in-depth on top. */
++    if (!landlockSupportsScopeAbstractUnixSocket)
++        return;
++
++    ::landlock_ruleset_attr attr = {
++        /* This prevents multiple FODs from communicating with each other
++           via abstract sockets. Note that cooperating processes outside the
++           sandbox can still connect to an abstract socket created by the FOD. To
++           mitigate that issue entirely we'd still need network namespaces. */
++        .scoped = LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET,
++    };
++
++    /* This better not fail - if the kernel reports a new enough ABI version we
++       should treat any errors as fatal from now on. */
++    AutoCloseFD rulesetFd = landlockCreateRuleset(&attr, sizeof(attr), 0);
++    if (!rulesetFd)
++        throw SysError("failed to create a landlock ruleset");
++
++    if (landlockRestrictSelf(rulesetFd.get(), 0) == -1)
++        throw SysError("failed to apply landlock");
++
++    debug("applied landlock sandboxing");
++}
++
++#  else
++
++#    define DO_LANDLOCK 0
++
++#  endif
++
+ static void doBind(const Path & source, const Path & target, bool optional = false)
+ {
+     debug("bind mounting '%1%' to '%2%'", source, target);
+@@ -159,8 +241,27 @@ struct LinuxDerivationBuilder : virtual DerivationBuilderImpl
+ 
+     void enterChroot() override
+     {
++        /* Set the NO_NEW_PRIVS before doing seccomp/landlock setup.
++           landlock_restrict_self requires either NO_NEW_PRIVS or CAP_SYS_ADMIN.
++           With user namespaces we do get CAP_SYS_ADMIN. */
++        if (!settings.allowNewPrivileges)
++            if (::prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) == -1)
++                throw SysError("failed to set PR_SET_NO_NEW_PRIVS");
++
+         setupSeccomp();
+ 
++#  if DO_LANDLOCK
++        try {
++            setupLandlock();
++        } catch (SysError & e) {
++            if (e.errNo != EPERM)
++                throw;
++            /* If allowNewPrivileges is true and we don't have CAP_SYS_ADMIN
++               this code path might be hit. */
++            warn("setting up landlock: %s", e.message());
++        }
++#  endif
++
+         linux::setPersonality(drv.platform);
+     }
+ };
+@@ -709,4 +810,6 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
+ 
+ } // namespace nix
+ 
++#  undef DO_LANDLOCK
++
+ #endif
+diff --git a/tests/nixos/ca-fd-leak/default.nix b/tests/nixos/ca-fd-leak/default.nix
+index 902aacdc6..dc944290f 100644
+--- a/tests/nixos/ca-fd-leak/default.nix
++++ b/tests/nixos/ca-fd-leak/default.nix
+@@ -78,7 +78,7 @@ in
+ 
+       # Build the smuggled derivation.
+       # This will connect to the smuggler server and send it the file descriptor
+-      machine.succeed(r"""
++      sender_output = machine.succeed(r"""
+         nix-build -E '
+           builtins.derivation {
+             name = "smuggled";
+@@ -89,9 +89,13 @@ in
+             outputHash = builtins.hashString "sha256" "hello, world\n";
+             builder = "${pkgs.busybox-sandbox-shell}/bin/sh";
+             args = [ "-c" "echo \"hello, world\" > $out; ''${${sender}} ${socketName}" ];
+-        }'
++        }' 2>&1
+       """.strip())
+ 
++      # Landlock's LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET prevents a sandboxed process
++      # from connecting to an abstract socket created in an unrelated landlock domain.
++      # There's no such flag for preventing inbound connections.
++      assert "connect: Operation not permitted" in sender_output
+ 
+       # Tell the smuggler server that we're done
+       machine.execute("echo done | ${pkgs.socat}/bin/socat - ABSTRACT-CONNECT:${socketName}")

--- a/modules/shared/nix-security/patches/ghsa-g3g9-5vj6-r3gj-2.31.patch
+++ b/modules/shared/nix-security/patches/ghsa-g3g9-5vj6-r3gj-2.31.patch
@@ -1,0 +1,126 @@
+From df0153a9eca42c4ed5ac784657c8c5d0664c9e0e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Mon, 6 Apr 2026 16:49:13 +0200
+Subject: [PATCH] Fixes for GHSA-g3g9-5vj6-r3gj
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Squashed commit of the following:
+
+commit bf1d95ae399e47daeafa9e0dfac967f415c52447
+Author: Sergei Zimmerman <sergei@zimmerman.foo>
+Date:   Fri Apr 3 00:21:31 2026 +0300
+
+    derivation-builder: Don't use copyFile for FOD output copying, put the output in a temporary directory in the store
+
+commit ca5986fa353d402738acf961bcaa017c61019809
+Author: Sergei Zimmerman <sergei@zimmerman.foo>
+Date:   Fri Apr 3 00:21:21 2026 +0300
+
+    libstore: Make temporary in-store directory not world-readable
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ src/libstore/include/nix/store/local-store.hh |  2 ++
+ src/libstore/local-store.cc                   |  5 +--
+ src/libstore/unix/build/derivation-builder.cc | 36 ++++++++++++++-----
+ 3 files changed, 33 insertions(+), 10 deletions(-)
+
+diff --git a/src/libstore/include/nix/store/local-store.hh b/src/libstore/include/nix/store/local-store.hh
+index ec88ffb4f..91df9cd77 100644
+--- a/src/libstore/include/nix/store/local-store.hh
++++ b/src/libstore/include/nix/store/local-store.hh
+@@ -455,6 +455,8 @@ private:
+ 
+     friend struct PathSubstitutionGoal;
+     friend struct DerivationGoal;
++    /* Only used for createTempDirInStore. */
++    friend class DerivationBuilderImpl;
+ };
+ 
+ } // namespace nix
+diff --git a/src/libstore/local-store.cc b/src/libstore/local-store.cc
+index d24bc415c..524a9fdda 100644
+--- a/src/libstore/local-store.cc
++++ b/src/libstore/local-store.cc
+@@ -1342,8 +1342,9 @@ std::pair<std::filesystem::path, AutoCloseFD> LocalStore::createTempDirInStore()
+     do {
+         /* There is a slight possibility that `tmpDir' gets deleted by
+            the GC between createTempDir() and when we acquire a lock on it.
+-           We'll repeat until 'tmpDir' exists and we've locked it. */
+-        tmpDirFn = createTempDir(config->realStoreDir, "tmp");
++           We'll repeat until 'tmpDir' exists and we've locked it.
++           Make the directory accessible only to the current user.*/
++        tmpDirFn = createTempDir(config->realStoreDir, "tmp", /*mode=*/0700);
+         tmpDirFd = openDirectory(tmpDirFn);
+         if (!tmpDirFd) {
+             continue;
+diff --git a/src/libstore/unix/build/derivation-builder.cc b/src/libstore/unix/build/derivation-builder.cc
+index 73bb026a2..d11f80159 100644
+--- a/src/libstore/unix/build/derivation-builder.cc
++++ b/src/libstore/unix/build/derivation-builder.cc
+@@ -1473,6 +1473,13 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
+         assert(output && scratchPath);
+         auto actualPath = realPathInSandbox(store.printStorePath(*scratchPath));
+ 
++        /* An optional file descriptor of a directory used for intermediate
++           operations. */
++        AutoCloseFD tempDirFd;
++        /* RAII cleanup of a temporary directory inside the store that is used
++           for intermediate operations. */
++        std::optional<AutoDelete> delTempDir;
++
+         auto finish = [&](StorePath finalStorePath) {
+             /* Store the final path */
+             finalOutputs.insert_or_assign(outputName, finalStorePath);
+@@ -1607,6 +1614,25 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
+             return newInfo0;
+         };
+ 
++        auto moveOutputToTempDir = [&]() -> void {
++            std::filesystem::path tempDir;
++            std::tie(tempDir, tempDirFd) = store.createTempDirInStore();
++            delTempDir.emplace(tempDir);
++
++            auto tmpOutput = tempDir / "x";
++
++            /* Serialise and create a fresh copy of the output to break
++               any stale writable file descriptors. Copy through the
++               serialisation/deserialisation. TODO: Use copyRecursive here and
++               make use of reflinking. */
++            auto source = sinkToSource([&](Sink & nextSink) { dumpPath(actualPath, nextSink); });
++            restorePath(tmpOutput, *source, settings.fsyncStorePaths);
++            /* This makes it slightly harder to make sense of the control flow. The rule
++               of thumb is that actualPath points to the current location of the stuff
++               that we'll end up registering. */
++            actualPath = std::move(tmpOutput);
++        };
++
+         ValidPathInfo newInfo = std::visit(
+             overloaded{
+ 
+@@ -1634,14 +1660,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
+ 
+                 [&](const DerivationOutput::CAFixed & dof) {
+                     auto & wanted = dof.ca.hash;
+-
+-                    // Replace the output by a fresh copy of itself to make sure
+-                    // that there's no stale file descriptor pointing to it
+-                    Path tmpOutput = actualPath + ".tmp";
+-                    copyFile(std::filesystem::path(actualPath), std::filesystem::path(tmpOutput), true);
+-
+-                    std::filesystem::rename(tmpOutput, actualPath);
+-
++                    moveOutputToTempDir();
+                     auto newInfo0 = newInfoFromCA(
+                         DerivationOutput::CAFloating{
+                             .method = dof.ca.method,
+@@ -1682,6 +1701,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
+                 },
+ 
+                 [&](const DerivationOutput::Impure & doi) {
++                    moveOutputToTempDir();
+                     return newInfoFromCA(
+                         DerivationOutput::CAFloating{
+                             .method = doi.method,


### PR DESCRIPTION
The build infrastructure runs as a multi-tenant target for arbitrary nix builds, which makes it a high-value setting for the two FOD-related vulnerabilities currently outstanding against nix 2.31:

  - GHSA-g3g9-5vj6-r3gj: std::filesystem::copy_file follows symlinks when copying FOD outputs, allowing a malicious builder to overwrite files outside the build sandbox.
  - CVE-2025-46416: cooperating builders can smuggle file descriptors via abstract unix sockets and race filesystem operations of an outside process, escalating to the build user.

Both fixes are still working their way through upstream review, so override nix.package with nixComponents_2_31.appendPatches against the 2.31.3 tag nixpkgs pins. The shared source-patched-source threads the patches through every modular nix component, and scoping the override to nix.package keeps the rest of pkgs unperturbed. Drop this once the equivalent fixes land in the nixpkgs input.

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
