### PR TITLE
terrafor/hydra-projects: fetch main branch for nixos-mailserver

### DIFF
--- a/terraform/hydra-projects.tf
+++ b/terraform/hydra-projects.tf
@@ -66,7 +66,7 @@ resource "hydra_project" "simple_nixos_mailserver" {
   declarative {
     file  = ".hydra/spec.json"
     type  = "git"
-    value = "https://gitlab.com/simple-nixos-mailserver/nixos-mailserver"
+    value = "https://gitlab.com/simple-nixos-mailserver/nixos-mailserver main"
   }
 }
 


### PR DESCRIPTION
Instead of the default branch hydra defaults to the master branch if no branch is specified. We therefore need to be explicit here.

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
