### PR TITLE
modules/nixos/common: fix systemd-tmpfiles

### DIFF
--- a/modules/nixos/common/kernel.nix
+++ b/modules/nixos/common/kernel.nix
@@ -34,5 +34,15 @@ in
           };
       }
     );
+
+    systemd.package = pkgs.systemd.overrideAttrs (o: {
+      patches = o.patches ++ [
+        (pkgs.fetchpatch {
+          name = "tmpfiles:_do_not_require_STATX_ATIME.patch";
+          url = "https://github.com/systemd/systemd/pull/41232.patch";
+          hash = "sha256-PDh4mP9rYGCglp25346nExU2v6P0WYPfLZgu+YwzZ9c=";
+        })
+      ];
+    });
   };
 }


### PR DESCRIPTION
> statx() does not support 'STATX_ATIME' mask (running on an old kernel?)
> statx(/var/tmp) failed: Protocol driver not attached

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
