### PR TITLE
nixos/community-builder: add scrumplex

### DIFF
--- a/modules/nixos/community-builder/keys/scrumplex
+++ b/modules/nixos/community-builder/keys/scrumplex
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJV9lYhi0kcwAAjPTMl6sycwCGkjrI0bvTIwpPuXkW2W scrumplex

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -236,6 +236,12 @@ let
       keys = ./keys/schmittlauch;
     }
     {
+      # lib.maintainers.Scrumplex, https://github.com/Scrumplex
+      name = "scrumplex";
+      trusted = true;
+      keys = ./keys/scrumplex;
+    }
+    {
       name = "skowalak";
       trusted = true;
       keys = ./keys/skowalak;


### PR DESCRIPTION
Due to my maintenance of packages like curl, unbound or pnpm, I have to rebuild
a lot of packages regularly and it's getting out of hand when these get updated
at the same time. I would really appreciate if I can get access to the
community builders to accelerate my builds.
