### PR TITLE
modules/nixos/buildbot: add patsh

### DIFF
--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -27,6 +27,7 @@ let
     "nix-community/nixpkgs-update"
     "nix-community/nixpkgs-xr"
     "nix-community/nixvim"
+    "nix-community/patsh"
     "nix-community/srvos"
     "nix-community/stylix"
     # keep-sorted end


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

it is running on hercules ci right now, but seems like the plan in the future is to move everything to buildbot: #1957

also removed the github workflow in https://github.com/nix-community/patsh/commit/953d3e844924d0f928bd06dbe5a97d9ca81924c6 which used the org token, since it was doing essentially the same thing: #532