### PR TITLE
nixpkgs-update: add nix-eval-jobs for nixpkgs-review

### DIFF
--- a/hosts/build02/nixpkgs-update.nix
+++ b/hosts/build02/nixpkgs-update.nix
@@ -25,6 +25,7 @@ let
     coreutils
     gist
     nixpkgs-review
+    nix-eval-jobs
     tree
   ];
 


### PR DESCRIPTION
seems to have been missed in https://github.com/NixOS/nixpkgs/commit/0a23fbeecacdbb6bdf9fdf7cfd4a5fe1147ed72d

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
