### PR TITLE
nixos/community-builder: add herbetom

### DIFF
--- a/modules/nixos/community-builder/keys/herbetom
+++ b/modules/nixos/community-builder/keys/herbetom
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKMt6RryvJnQ44t7j1LprsS+sHUjWVzOrdtOR2Yz1I65 herbetom@nix-community-builder v1

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -489,6 +489,12 @@ let
       trusted = true;
       keys = ./keys/miniharinn;
     }
+    {
+      # lib.maintainers.herbetom, https://github.com/herbetom
+      name = "herbetom";
+      trusted = true;
+      keys = ./keys/herbetom;
+    }
   ];
 in
 {


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

I would like to ask for considerations of granting me access to the community builders.

I'm a maintainer of a couple of packages. I'm currently lacking the ability to run nixosTests on aarch64. In addition i'm currently more or less limited to a 3 core aarch64 build VM which isn't really all that much. This means i'm currently often not doing aarch64 builds since it just isn't feasible. Changing that would be kinda great.