### PR TITLE
nixos/community-builder: add quantenzitrone

### DIFF
--- a/modules/nixos/community-builder/keys/quantenzitrone
+++ b/modules/nixos/community-builder/keys/quantenzitrone
@@ -1,0 +1,2 @@
+sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIEHxSon5NqDQ35sRfV8HwPqyhtoJ+jX705jhwSet8qgsAAAADHNzaDpuaXRyb2tleQ== nix@dev.quantenzitrone.eu
+

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -502,6 +502,13 @@ let
       shell = pkgs.fish;
       keys = ./keys/wegank;
     }
+    # lib.maintainers.quantenzitrone, https://github.com/quantenzitrone
+    {
+      name = "quantenzitrone";
+      trusted = true;
+      shell = pkgs.fish;
+      keys = ./keys/quantenzitrone;
+    }
   ];
 in
 {


### PR DESCRIPTION
i need to build a nixos test on aarch64-linux to fix the failure
https://hydra.nixos.org/build/328796987