### PR TITLE
nur-update: update flake input, use GitHub app for auth

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -389,11 +389,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778542737,
-        "narHash": "sha256-h5cLW9ALNrY6qb4dGjGoZOGkny9kaELnbOV1BFIrWuo=",
+        "lastModified": 1779640583,
+        "narHash": "sha256-QoDwFFaEQLu7mw80XL667C3x4QcDBTSt6jCBtzornhk=",
         "owner": "nix-community",
         "repo": "nur-update",
-        "rev": "f4afd9f4d363bbc05fb3fc685ece885a83174757",
+        "rev": "5ea87c052f81e2a8c535d319c89e9091d06fc9c4",
         "type": "github"
       },
       "original": {

--- a/hosts/web01/secrets.yaml
+++ b/hosts/web01/secrets.yaml
@@ -1,11 +1,10 @@
 nix-community-matrix-bot-token: ENC[AES256_GCM,data:rUi+deMQLcD0LnzpZqeezdbtwZNhHwUWMv5KlEBfWcWqJ3cZIV66G6L5MJ7v4b0r7OKrVSpQDinb+UXALO975OMr9L6EvO4Lx1RMxA==,iv:7ljmHi+P9cVVyJhpqyVvaAVy4ledqYFuqjX71J8fCk8=,tag:dAX+cJZbZ+1T9OHT57wxhA==,type:str]
 oauth2-proxy-key-file: ENC[AES256_GCM,data:HaW/nIfUdrilacO9JzsEvOA+pxZ4RKxJUN8jHSEyy50g8//RRpflR+fLXZoaAOV9hE7ztWa39EqTxGAi0AKWUCrS0v72NfI+WVfsdEOifQrkPFh67fRlD7xTDDVB6hmP4JczIpu+3kGJhZm5KuQ7bNeaf6PJF1QKQ+gXYeXR3NAszfoObRq+SYR4CmA=,iv:HELIcLH/2+ve5xT3VDXClVwGHMSyLmVfJcZ/RWD/x64=,tag:5NiDA1vketWZjE5NlaQE+A==,type:str]
-nur-update-github-token: ENC[AES256_GCM,data:m5ua0PHtBWUoo29T8Y0U2QLN7YfgVIKr4a9WK0mAtu1Rgt0ExFxoHw==,iv:oJx5oUtqV6w1JfZe3ZmEaxwxJpzdoYsLdlZZjI0nbrk=,tag:ZRZc+okrI7Nipk9BAVeaqw==,type:str]
+nur-update-github-app-private-key: ENC[AES256_GCM,data:V7lZPeQFXpSn0/BkfftDIVguObv3479YjOhU1TosUnzhgUresNxI6UZ48cwSxZo4dznK4cEW7Ett857AJQQENjzsxn/EAkfVuMcoNBM6AXOILUr98+VAHwAr/dAWnLHiYGGbgKw3+oRYE5G30NaqZG6BnscVPytUCHH5QKI2sggefxlN429wJFg+oKH8Kfi39RDmmfGWS9T1G0dHAAYo6wKn6pO+p+I7TFkAsxQFjoA+OGcty0awJeOrmzPxvx1PBXyupK1xrOzdwUhU3DZ2b4h9o1g8SpeJyi65wucmtUTZLktSQJQeJv25t/gXTrmQgFq4NMV3bFbGc0svwUbzINfXJh/CWBMV1ex/ldRKmbRe0LtshmU0Owdl5//mRw09J/0xuKNl5POVS3Xn3GuogVQpNIbMTk4Jft3mY8uic9gPKNplj5t5MtwhMVo6ZAkrjl4Z5Jm2n6XFVCx/pLUYSJXfBV38ZqX79ZxJoFURlZl7J1sAWr/7oAST3bIqobkPCBJUbqx7lxVz1lDWOPCENsdLavGmRbI+BCY2Kv/5DKtoI3LEtpsl4ldLxhrmvFSGXrNhMZ6A5RN5+jerwVXMCBC0u0HwS0TusAPBS/Q1QCktRy5ac9Se0keOhWSJLUreyq4+x/TidZ6UfxMNOpWenDX/wVvezUl/sr3YeOcmgil409YBMmT50FebkWK2Xdx2t8p7r9UJf2tURP5tVhNkcgOQg9SLz2N+DJOXjUA8eeXn21YmNGccCVDfmO6XIB5J4/8K8tJxYPmyasnzFKrSgTKzmyzZEL/hzzQssE873GygYCXWgfHEwDgsgXtD9L2cSy4R0wRKVfWWQMuM6vXiugeEWg3ec6wryEm24GPzZ8lwA7H5qAhnTUt0COh3/HoVqWj2LL4bu5pmKNZ3udc3lIqhtOMyHKlB59yVBKiQoHzk3OcJdyf5EnwjNPhuR2q4dXnzRSaR2KzkxoNbRMRy4UkPHTvkUC0hn/RxsUX/2NPiGnBNmCv7aU2L3l7QPbbk3vSFCwU2zb44qgCcTBIQEGTccCCcd2YhOoxkVEACe0MCiGy4DoCJ/UK68YL6qB0w0UET1jeYqkqFSLVHwrFQaPUYu0gAld235Ld7bO2aOESnsAxjn3RNAvj9m8mVyLy54pcgfZCdZkxy+dgXK5bXuLYMGTXWo9KDsv9YO+mq3XKBoDG54CC204t5wlfg0xavrrqiXTNPmxpkpDdOhlFgdqvOmoKeEI30Xq55cu1FGsgr+geYo1pyx0w+lmOZQe1y62ji0NUAmUPhKDw94VEOIKelfVH1ET5Y1T+fwcdzq0r/quW0El/0EjmbKinDcMMSteLODvKr4JmZtoYq8ugvNvN1sE3nCAkkxFMDabH8JzLgUc2dWgk1PGye6u+BKSIm19jUd2utewS0HNB0/W4K4QamI81nZ8BYrpnIUNy4hNOn1TEJphS/h6Rq/opwqeLuww9q3ujKp8vrPO67A+teYajxqbSDGVWGG0zd3i0Al6uuXzuZA6QmV3fuHy7z31PvB/2LSReUqjLsxY88oYJXFpwK/dKakaKRuYa4/dYN24mU0k9jK7ByH++MWqUa/zCm/b+jFFASBs2Tlpw2RUEexDpIxFfGYLkmzIcYQ6wFoi0r4SxGFrpVsWXhKhUh6QViBjKZa8ozcZP3PLQ/hkY8iu+Hk/hNxm4y0Ble7E3sKMkh+CKse/mRC49UJgQOX9lzONmpZlk6uHlqM/+dQN6ndunNyj4EobTgW1kTjQYjX9JS9U+MZy3L9AUvGlVv2Y3d1RtalQKWVNNyoYtRsaIXsn+U4R1XfL6vJoRLDQbmk8XxfK3uK8Bbg3IOEFwqrQ2VOj7wReKA9HXr5W8yD5xQ3ENoVxRAu8xh/B2HYxhio1RKxVJsVxqeIGZoMTm6N+6mBUP/Od8zIaoJhzNiB0gGbi7zMiNXUAlp3RrtSoG8ctYdxLqXR8opv9h9EUpUENboVis6w9auRyHKYjaH7nVXOKN0JFDEgqoZaMeJ/wSiUiO4Hd66P7xPK42CISCnrEvm+uxAlKmkE/wdNOTkUG32tZxFlrl1ODlAoTBdjTdYuOCP/jV9Q737IM4gEH93s3w1GpshVHvv4/FDcS0fekQfXtgKT2mW/sDDD8nBv9i1ohKRLaJwc9pfPD2hPDosKPvrjZcnCdLTYmEs0j0BKVhf3nPkR3XrP6kGG3YCbPNPzF33dAG2UO1drt5KsLrOFEQ=,iv:SumpbU667aPBr4WTUF2bD9+67JEXwrd8WCMj8e1eo4k=,tag:B5RDJRT/MetztrACsK1flw==,type:str]
 rfc39-record-ssh-key: ENC[AES256_GCM,data:HzKUK2K0HD+OYhVnP+bu8TgGpC+ep9WVWDVakw0lUovs+FDHm4ikf66NOthjOdsq4B0NAglabcqDnY2eDOk3I8EpsrrUXCy1FnYTM28BgKoTJWFl/ob5OJvSpmi7M8+w46nT3Cdy0c9atE3hVaS1gRm7O+rVIMSaVV5qbfHwyMTYS5Jc8NvEsUK6MnzSrLIjYIurd+z0j5lmHdSt+LzcnTkiQ36kzPbyQLMJIOwv5zwq33oLfK6qRUiIrnrhXL34iCZYAsF2Zo1cmtTIrICZ49+8pokd11yscN7tYWtUUvDy0qcVDuFoFm4OMe3/nxCTNx1fC3+WtilvdjpZ6NrRM+knPQAMafVO+meedqmdCSfNY8MtaotEAT3CZCQcKRDsuxWSc77g8+gKVZnZQ323aZ5X8YqQEA6Vv6Gf4NhfoSZ2+/qPNI9yud0MkDJ84YlNEVMFcTXhF33cKsikGvNxZmHFcgKRbPObOWbHP878Wsk0/ROR98IKXfAO+6npMak0ZKS7,iv:EzxiQ4/mM84U1/mZRD9uzfrrvdaI4YUYqWrDH5U+Oas=,tag:96hEB5AQv4CnXx4y9Z5FPQ==,type:str]
 sops:
     age:
-        - recipient: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILAkBZMRNgsJ/IbLtjMHqBw/9+4tyn9nT+5B5RFiV0vJ
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IG1lemEyZyBjeWZx
             U0V2NUhBMlBvTy9GWW0yRk1mY041dmZXcUNZVjI3eXFUZEhQdVZFCmJDOEVSVk1M
@@ -14,8 +13,8 @@ sops:
             +nYHmm4akw3e2kOLEzS/905dnTqRzAiOf0+vt/wCMye90rL0gh92HuBwr92EF81d
             MUei2Q==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1dzvjjum2p240qtdt2qcxpm7pl2s5w36mh4fs3q9dhhq0uezvdqaq9vrgfy
-          enc: |
+          recipient: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILAkBZMRNgsJ/IbLtjMHqBw/9+4tyn9nT+5B5RFiV0vJ
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2bDYweHFQTHJhcHd1YVJp
             WVRvQWR1S1NldEt5ZTM0T2Rod01ncHY2bHhZCjJiZ0xOa3RLVnZJK2pTb0FyWTlm
@@ -23,8 +22,8 @@ sops:
             MEFNYnJscWQ2UHJsNitaUkNBb2J0aTgKmmntZzxPzTeKnlqnItjsxpofnnuW6YHJ
             tC7JjVKuK1yGuCLg3ks7EoFKM2w//fIJHpKhDCw8n5yv2qT37ehQPw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1egv86plsncnz5cuaua42tzd2xqyty82n5sgnd4xkux9lz8udssds7vymye
-          enc: |
+          recipient: age1dzvjjum2p240qtdt2qcxpm7pl2s5w36mh4fs3q9dhhq0uezvdqaq9vrgfy
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPWnhWQTZVRWJzU1ZDT1JY
             RGRXVytRdHBkdnpIMVFockpmWWxFbFg2NXdjCkhDQ0RDb3REc1lQaWdEVTcyUFZU
@@ -32,8 +31,8 @@ sops:
             RVhHOTBOM3lVa2l4V1ZjTWoyR0YyMFEKwvGRukQ7Ja0y5UhpCenl5moEDYOYFfYo
             uvpcod6S5xRll7A+HlJkugugLe0ia/FeudF+WCOYSWJcSEP+HxJbRw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age17n64ahe3wesh8l8lj0zylf4nljdmqn28hvqns2g7hgm9mdkhlsvsjuvkxz
-          enc: |
+          recipient: age1egv86plsncnz5cuaua42tzd2xqyty82n5sgnd4xkux9lz8udssds7vymye
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBZCtYbjNQNlZhOUxVWGU5
             VEorSGJjVXR5MVRCUlRObnRLMlVrT0p6QTJBClZwQVV4Nkp0WWllakJBWk5iaThN
@@ -41,8 +40,8 @@ sops:
             VEgrR3Q4ZkhSQUxHYkFLa2I0YysxK2cKB7v+OvxN9DPP8RyESFHC3tkutpOAf8Lf
             K1ZaBGinN4B39XR22fw3rdI3GgmVRegE4OFlVT5qgHbZ2wGG6qPVpg==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1d87z3zqlv6ullnzyng8l722xzxwqr677csacf3zf3l28dau7avfs6pc7ay
-          enc: |
+          recipient: age17n64ahe3wesh8l8lj0zylf4nljdmqn28hvqns2g7hgm9mdkhlsvsjuvkxz
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFTTNYWHN3ZzYxb25SeDc3
             dU9vekY3dHFIQ2VsQ0VkSXZmUXd5YjY3RkZrCndxNjl3ZVQ4ZE5zMXhpK0QvV0pW
@@ -50,8 +49,8 @@ sops:
             K0ZIS3JiZ1ZWdHVDeGxnU3dhVGpwOUkKRK6Qt+wkdxCCrWUK8czxH1aJsLr40COV
             YgYI0SlEA/q3GgceU2PcV38HnC5yxBLdL1JWG+1xqUqmraDXcsqGSA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h
-          enc: |
+          recipient: age1d87z3zqlv6ullnzyng8l722xzxwqr677csacf3zf3l28dau7avfs6pc7ay
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2RDJFZlFMZnJsUGh1cHpW
             YnAyRmt3NjZnTXgrYjhhamd1QW11OVhrZWlFCklYMktRT1AxVXNpOWFic3licWg0
@@ -59,8 +58,8 @@ sops:
             dHZiMmlQMFEzMnZnVTF4RFhmVDZ5aDgKKXfseF98Ss6APxxospknAc9qK2WkR9TS
             bZAal7J2oS7VzVANGSnXBvVYTHSFXyUlBLxEAEEcsElK2sZE0aOItA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1m7xhem3qll35d539f364pm6txexvnp6k0tk34d8jxu4ry3pptv7smm0k5n
-          enc: |
+          recipient: age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDMmlsWXNjS1krbGpINkEz
             TVQzUTdzQm56dG9ydWhJNG1yM0NpeGVIaGc4CjFZOEprL0R2YkN6T1ZsYjUwTEgz
@@ -68,7 +67,8 @@ sops:
             WVNBZzJ1RGc3K2ZyajJveW5URkhSN0UKWDiorZG/YN/Szj3N6KQV4kQPKmjcq2Ne
             t0PRY5o+UbacWXJqqQ+veWtQKJtTBEAnwBFdnkjORga9tywapWlVrw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-14T22:54:59Z"
-    mac: ENC[AES256_GCM,data:2oruHg+fJh1vEwTUom8JuF5r8/Srj7jIG0zKuv/UKzCDLqkDT5YCgnFBTrj5BX8UHfaOZZNa3t6zsFGxEl3IAno9vo5RDH3wfG0hmWKqfmkL28g+uETEKqy4rkx5ONLbK5WOyzz0OY58nVpsjMcOYb+2KN2s5WMHKBcDeE6Oq0M=,iv:bqbkbYNgj5G4MkzI0T4sl4oaCsLJThxcpteH9xjhy0s=,tag:2X49tC3v7DoLXWJD7II8dg==,type:str]
+          recipient: age1m7xhem3qll35d539f364pm6txexvnp6k0tk34d8jxu4ry3pptv7smm0k5n
+    lastmodified: "2026-05-24T17:23:16Z"
+    mac: ENC[AES256_GCM,data:/xIqBEUagVi2WR11gv4Y4KGAxeGPVAM9S+BAedfPv0tYPMeSIctvh766cmtCe7fvHa46UgBIkGmSxaTmj7R7LK7LgOA5LiETJEd5/MCmR5MpRYTr+c9xX7/xSbNC1uHU9lhCrU1GjEJaPBurd0fYwXDlgQY59zmA8FkE/997nJY=,iv:tVUzsb+E8SO5lQ9/Vw8f716/k/dOFrq6siOtcrFKGjs=,tag:aYY3svKIDcUCAUCa8dmFAw==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.13.1

--- a/modules/nixos/nur-update.nix
+++ b/modules/nixos/nur-update.nix
@@ -10,7 +10,7 @@
     locations."/".proxyPass = "http://unix:/run/nur-update/gunicorn.sock";
   };
 
-  sops.secrets.nur-update-github-token = { };
+  sops.secrets.nur-update-github-app-private-key = { };
 
   systemd.services.nur-update =
     let
@@ -24,7 +24,9 @@
     {
       description = "nur-update";
       script = ''
-        GITHUB_TOKEN="$(<"$CREDENTIALS_DIRECTORY"/github-token)" \
+        GITHUB_APP_PRIVATE_KEY="$(<"$CREDENTIALS_DIRECTORY"/github-app-private-key)" \
+        GITHUB_APP_ID=3842714 \
+        GITHUB_APP_INSTALLATION_ID=135242817 \
           ${python}/bin/gunicorn nur_update:app \
           --bind unix:/run/nur-update/gunicorn.sock \
           --log-level info \
@@ -33,7 +35,9 @@
       '';
       serviceConfig = {
         DynamicUser = true;
-        LoadCredential = [ "github-token:${config.sops.secrets.nur-update-github-token.path}" ];
+        LoadCredential = [
+          "github-app-private-key:${config.sops.secrets.nur-update-github-app-private-key.path}"
+        ];
         Restart = "always";
         RuntimeDirectory = "nur-update";
       };


### PR DESCRIPTION
See https://github.com/nix-community/NUR/issues/1138.

Flake lock file updates:

• Updated input 'nur-update':
    'github:nix-community/nur-update/f4afd9f4d363bbc05fb3fc685ece885a83174757?narHash=sha256-h5cLW9ALNrY6qb4dGjGoZOGkny9kaELnbOV1BFIrWuo%3D' (2026-05-11)
  → 'github:nix-community/nur-update/5ea87c052f81e2a8c535d319c89e9091d06fc9c4?narHash=sha256-QoDwFFaEQLu7mw80XL667C3x4QcDBTSt6jCBtzornhk%3D' (2026-05-24)

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
