### PR TITLE
chore(community-builders): add britter

### DIFF
--- a/modules/darwin/community-builder/keys/britter
+++ b/modules/darwin/community-builder/keys/britter
@@ -1,0 +1,2 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN08p42pc+/1ijgTstQ9xRxu23VLyO+AM4j7zFghUil/ britter@thinkpad-x1
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGsQc3GN4b8scuDR7PghdB+Eu4zUgSwgrgqplpNDR3Lq britter@framework-13

--- a/modules/darwin/community-builder/users.nix
+++ b/modules/darwin/community-builder/users.nix
@@ -559,6 +559,13 @@ let
       uid = 584;
       keys = ./keys/dwt;
     }
+    {
+      # lib.maintainers.britter, https://github.com/britter
+      name = "britter";
+      trusted = true;
+      uid = 585;
+      keys = ./keys/britter;
+    }
   ];
 in
 {

--- a/modules/nixos/community-builder/keys/britter
+++ b/modules/nixos/community-builder/keys/britter
@@ -1,0 +1,2 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN08p42pc+/1ijgTstQ9xRxu23VLyO+AM4j7zFghUil/ britter@thinkpad-x1
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGsQc3GN4b8scuDR7PghdB+Eu4zUgSwgrgqplpNDR3Lq britter@framework-13

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -514,6 +514,12 @@ let
       shell = pkgs.fish;
       keys = ./keys/quantenzitrone;
     }
+    {
+      # lib.maintainers.britter, https://github.com/britter
+      name = "britter";
+      trusted = true;
+      keys = ./keys/britter;
+    }
   ];
 in
 {


### PR DESCRIPTION
I work on the Java ecosystem in nixpkgs. Changes to foundational packages such as `maven` or `gradle` tend to generate a large number of downstream rebuilds, which makes running `nixpkgs-review` against those PRs infeasible on my personal x86_64 laptop, both because of the sheer volume of builds and because I have no way to evaluate other architectures without emulation.

Access to the community builders (Linux x86_64, Linux aarch64, and darwin) would let me properly evaluate the impact of my changes before requesting merge.

Two SSH keys are added, one per machine I work from (thinkpad-x1, framework-13). Public keys are also published at https://github.com/britter.keys.