### PR TITLE
nixos/community-builder: add ysun

### DIFF
--- a/modules/nixos/community-builder/keys/ysun
+++ b/modules/nixos/community-builder/keys/ysun
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBqRqPQMMabdwl/C/JWcTcAS5oj+T7hKhaEGjGl13SgO ysun@nix-community.org

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -520,6 +520,13 @@ let
       trusted = true;
       keys = ./keys/britter;
     }
+    {
+      # lib.maintainers.stepbrobd https://github.com/stepbrobd
+      name = "ysun";
+      trusted = true;
+      shell = pkgs.zsh;
+      keys = ./keys/ysun;
+    }
   ];
 in
 {


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Hello! Sometimes I need to run VM tests and builds for package bumps on aarch64-linux, binfmt is wayyy to slow

I do have a rpi5 but I'm running a [gps time server](https://time.ysun.co/) on it, put heavy load on it will skew the accuracy quite a bit (well, also its not really fast)

Thus I would like to request access to the aarch64-linux community builder, thanks!