### PR TITLE
modules/nixos/monitoring/alert-rules: increase NixpkgsOutOfDate to two weeks

### DIFF
--- a/modules/nixos/monitoring/alert-rules.nix
+++ b/modules/nixos/monitoring/alert-rules.nix
@@ -51,6 +51,11 @@
           annotations.description = "{{$labels.host}} should have a running {{$labels.name}}";
         };
 
+        NixpkgsOutOfDate = lib.mkForce {
+          expr = ''(time() - flake_input_last_modified{input="nixpkgs"}) / (60*60*24) > 14'';
+          annotations.description = "{{$labels.host}}: nixpkgs flake is older than two weeks";
+        };
+
         SmartErrors.expr = lib.mkForce ''smart_device_health_ok{enabled!="Disabled", host!="build05"} != 1'';
       };
   };


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Mostly following kernel updates and the staging-nixos cycle, seven days sometimes doesn't align with that and can cause an unnecessary rebuild of the kernel and needing to reboot the hosts.