### PR TITLE
modules/nixos/common: disable installerTools

### DIFF
--- a/modules/nixos/common/default.nix
+++ b/modules/nixos/common/default.nix
@@ -1,6 +1,7 @@
 {
   config,
   inputs,
+  lib,
   pkgs,
   ...
 }:
@@ -30,12 +31,15 @@
     Restart = "on-failure";
   };
 
-  boot.kernelPackages = pkgs.lib.mkIf (
+  boot.kernelPackages = lib.mkIf (
     !config.boot.supportedFilesystems.zfs or false
   ) pkgs.linuxPackages_latest;
 
   # subuid/subgid support: https://github.com/nikstur/userborn/issues/7
   services.userborn.enable = false;
+
+  system.disableInstallerTools = lib.mkDefault true;
+  system.tools.nixos-rebuild.enable = true;
 
   zramSwap.enable = true;
   zramSwap.memoryPercent = 100;

--- a/modules/nixos/community-builder/default.nix
+++ b/modules/nixos/community-builder/default.nix
@@ -11,6 +11,8 @@
     ./users.nix
   ];
 
+  system.disableInstallerTools = false;
+
   users.motd = config.nixCommunity.motd;
 
   programs.mosh = {


### PR DESCRIPTION
- keep nixos-rebuild enabled

- keep them enabled on the community builders like we do with docs, etc

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
