### PR TITLE
{darwin,nixos}/community-builder: add gepbird

### DIFF
--- a/modules/darwin/community-builder/keys/gepbird
+++ b/modules/darwin/community-builder/keys/gepbird
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID799rcrUU09obAHEqsXteQxPYIedCFlFr3tf0XDDowM gep@geptop-xmg

--- a/modules/darwin/community-builder/users.nix
+++ b/modules/darwin/community-builder/users.nix
@@ -566,6 +566,13 @@ let
       uid = 585;
       keys = ./keys/britter;
     }
+    {
+      # lib.maintainers.gepbird, https://github.com/gepbird
+      name = "gepbird";
+      trusted = true;
+      uid = 586;
+      keys = ./keys/gepbird;
+    }
   ];
 in
 {

--- a/modules/nixos/community-builder/keys/gepbird
+++ b/modules/nixos/community-builder/keys/gepbird
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID799rcrUU09obAHEqsXteQxPYIedCFlFr3tf0XDDowM gep@geptop-xmg

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -527,6 +527,13 @@ let
       shell = pkgs.zsh;
       keys = ./keys/ysun;
     }
+    {
+      # lib.maintainers.gepbird, https://github.com/gepbird
+      name = "gepbird";
+      trusted = true;
+      shell = pkgs.zsh;
+      keys = ./keys/gepbird;
+    }
   ];
 in
 {


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

I'm mainly maintaining pnpm that has a growing number of rebuilds, the linux builds have been mostly fine on my machine but sharing the build results with other maintainers and the extra speed would be nice.
I'd really appreciate access to the darwin builder as my best access to one was GHA runners which are not too reliable, I've seen many builds pass on Hydra but fail on GHA.