### PR TITLE
nixbot

### DIFF
--- a/dnscontrol/dnsconfig.js
+++ b/dnscontrol/dnsconfig.js
@@ -60,6 +60,7 @@ var cnames = {
     "docker": "nix-community.docker.scarf.sh.", // Used by nix-community/nixpkgs-docker
     "hydra": "build03",
     "landscape": "web01",
+    "nixbot": "build03",
     "nixpkgs-update-cache": "build02",
     "nixpkgs-update-logs": "build02",
     "nl.meet": "nixnl.codeberg.page.",

--- a/flake.lock
+++ b/flake.lock
@@ -265,6 +265,30 @@
         "type": "github"
       }
     },
+    "nixbot": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781059692,
+        "narHash": "sha256-WmCLlOX/3ZwHNxrBnLwKu4/dY6prYp3cuO4DsI60ilE=",
+        "owner": "qowoz",
+        "repo": "nixbot",
+        "rev": "3d3d51d6a53db6a036c0a6e220e6789a9e4df34b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "qowoz",
+        "ref": "infra",
+        "repo": "nixbot",
+        "type": "github"
+      }
+    },
     "nixbsd": {
       "inputs": {
         "cppnix": [
@@ -438,6 +462,7 @@
         "mimalloc-nix": "mimalloc-nix",
         "nix-darwin": "nix-darwin",
         "nix-index-database": "nix-index-database",
+        "nixbot": "nixbot",
         "nixbsd": "nixbsd",
         "nixbsd-nixpkgs": "nixbsd-nixpkgs",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,9 @@
     nix-darwin.url = "github:nix-darwin/nix-darwin";
     nix-index-database.inputs.nixpkgs.follows = "nixpkgs";
     nix-index-database.url = "github:nix-community/nix-index-database";
+    nixbot.inputs.nixpkgs.follows = "nixpkgs";
+    nixbot.inputs.treefmt-nix.follows = "treefmt-nix";
+    nixbot.url = "github:qowoz/nixbot/infra";
     nixbsd-nixpkgs.url = "git+https://github.com/NixOS/nixpkgs?shallow=1&rev=15ebe06759175c2e98dba23c0b125913589094e7";
     nixbsd.inputs.cppnix.follows = "freebsd-nix";
     nixbsd.inputs.flake-compat.follows = "flake-compat";
@@ -166,6 +169,7 @@
                 sops-check
                 terraform-validate
                 ;
+              nixbot-tests = inputs'.nixbot.packages.nixbot.tests.pytest;
               nixpkgs-update-supervisor-test = pkgs.callPackage ./hosts/build02/supervisor_test.nix { };
             }
             // lib.mapAttrs' (name: value: lib.nameValuePair "nixosTests-${name}" value) {
@@ -174,6 +178,7 @@
                 harmonia
                 hydra
                 ;
+              inherit (inputs'.nixbot.checks) nixbot;
               buildbot-nix = inputs'.buildbot-nix.checks.poller;
               buildbot-nix-scheduled-effects = inputs'.buildbot-nix.checks.scheduled-effects;
               quadlet-nix = inputs'.quadlet-nix.checks.nixos;

--- a/hosts/build03/default.nix
+++ b/hosts/build03/default.nix
@@ -12,6 +12,7 @@
     inputs.self.nixosModules.hercules-ci
     inputs.self.nixosModules.hydra
     inputs.self.nixosModules.nginx
+    inputs.self.nixosModules.nixbot
     inputs.self.nixosModules.watch-store
     inputs.srvos.nixosModules.hardware-hetzner-online-amd
   ];

--- a/hosts/build03/secrets.yaml
+++ b/hosts/build03/secrets.yaml
@@ -8,11 +8,13 @@ buildbot-github-oauth-secret: ENC[AES256_GCM,data:C5P54zotOwe3u2cOsJMKEVmZVH6hrL
 buildbot-github-webhook-secret: ENC[AES256_GCM,data:zHLoxsZtY8pzUyhKX2a501GxPLSORGHeSvFe9kVG1pUPayI4/mq9V2oAIHfdCwFz,iv:3LH1Tr2OipfpwQydXLutENaTgMr9ebvJx8rMjjksOw8=,tag:Lt8VCiAHoQxuyGrmM/tj3A==,type:str]
 buildbot-nix-worker-password: ENC[AES256_GCM,data:TaMHVzlzuAHfTBAyqG5JJFwpG2We+wlXva3YJnNkO9KSX9PIhnRHVES72jO63AkhvfBVEg==,iv:rTpaiCYcedcsy115BEDep68Mehb6knes7OxvBrEOrUQ=,tag:dD4Hg4oR3SfpYdP1e8V2jA==,type:str]
 buildbot-effects-nix-community-infra: ENC[AES256_GCM,data:wAYSvEza+1xjT/rIp5MtR3HEQe3OscRBtrWF/f6G/z+ftaiWXMfWhW9X8z53I20lzx9a6BqmO4jcWAGmXRSV4TX6wxKsUP9BnzxTImDS41zWfOtHV9sDifk6jmVJyAAsrY8CrebGTmPvWUXEUMmAZkUorQkv8gfxoL66GCtPfqa7d1OSKX8rAXd1YAJL58aXFeD6X6iZqo2tVd1OhlmUuFj5oum+9uLPjCY54IfilLlERw5DdTPDhMBdKt5owR0dpJDmp9t8i0AV2j4Hm36ZsY8L9ket1iB04MlapsUI24RiXHk+aFJqSy+0onvmqeniiBeaa106YomSQAS1cyOp0U+Rcqwhtnh9MNUZzciVXi2F5nkPzA3OcbQh8MDcJ/66z/VUkSac0iMXvr/47d5V0XCm9JSKXuijOUGTu9LRbdEAAQ+gsZ/Z8i6+9d75CeSoVH5Mtm7eU4CbhloNmpAcz5qyFf+sRgWz5qK8z1MwT795P/P/Oi2YQswtwnyLO7UkQ5tCrE+qcFxM9cAAcJzkzGctB5QdHDaPkkpMGic8vpAoYgx3t7Qmasuef96Fhhj4lk10sTTUrWZlnFbmduO/fDOULvisnW/BTpYsnsIPSKREg8wQAu7Fiu9EO0TZOagAQf03EiFDcxosetxPJIXoNWsZK/1LsX+7SnBBklVDtwxu6urOUCW8vYXD4aGZvkTGc6O6vwiOs+oEHd6J7Mes/+23hTzldnFobodwnzbRNVt/WT2FQjX5qFehyxbARL+EtT4MQC4sWGpXSybUs10=,iv:rdLHfK4NbCaMIIhhQd2MfVf1DdKKF9Sqe4Kxuy57yok=,tag:DPxsDTLIhA0d4KPXwseL9g==,type:str]
+nixbot-github-app-secret-key: ENC[AES256_GCM,data:OQHsN55CtdnWUlQOIfxOMVJEYMzALO61XS79BVZElCYTL5p7yuZ889Gvf5kkLJVMBjr0Cfk3aYFJLy1+Ax5nBe17DUzyZHHwvKNgzqBMrageRsNErF7jCzAVPWvbVjuJrWgA/9KqK4gqWgLGcJMrEtzcArVxClCKXH1GzB4u0GgVTEyYBdB97XuSZ6FFjJYRnPJqTXcd1v25632SNo03EZWGPcgQjek7Y7amlQ5w+u0EKnipb4uQO96vCe3IdD4/FVTT/n1R2aqO44JmC2rpDE+1iolIt30vIVbqH7BKDydlTP8/tpqq/hlhLyfZzXYz/BN62MiK31IXKAm7tcTwIQ1ArSHDO2urhxOFBL8dNxU1ZrjFBjYoYH9pGqU/qMoCzuZS0vv0+rdKApMbL7uwBbHOw93gpuX0KifD66xwdxPVGh1FCoA/Nphs+WY3q0lq8YJksm/lH8Re/kvDeBeCUelLEy3vyw/4LLghnaiP4o1AUQrjPv/1jWwwHrPtLfoN2zcq+AjKTsPOO8lQ5z+X3No4gsa503VuX8DCUhWkRs3em1KqB8Lq7HvogtIMCCP4REEYkkLsPqHVnFKhvcjG9KE24D0AB1erGDRwG49HcVoe3Osh7aF0a5VUDZT5QJ17jV8NVk4z9WQjcra12+aLQCDFEuqjS6bNA2/ZELqTQH59NRAhACWa1iOJkVLnI+MxNsmeDt7JRrB//hBOMC9NtgJkeGeZ546l9xfAFobIPDHs0DNK8GiMiaIh/RNsmaP+IBlK1kxAmiwfr1UUZWVmMZvA+DKVqOUh33kc/h+XB2M1dj+uiqnGUs8ec75FWBhH5NRo2YpxtLiiXgaSrpICcpDUE8W8c19rO+ZiXB7meo+TtLWGYr7XQozP8RE9CmujngLWH/HcORG//0SjBTZEr3HA2NWCEYthf7xGhYvrSDgfGNflRY5JSf9sg89Ovxs4F+Yb9WLGKQFCEM4Wx3FDCMDqWefVbnwqv3a2XAClsgmkmyfYgliKOBwOH5VfVoM8vLDvAz2b+upqM2aoPu78py48PTklnjw+0iK49u7Alrgcwp4VopY25/l6cdCyi140/IPPx6miuey11sCsT9X8vMekgHmkwtcEeyIdZEZqCi09+IBqm3ySZaiUI3tdO3ops2R1zzDJ4WgpOs+ZgvPeIrC4tROEnNxYM7RwX5eXwsgSR5uJJ924thN5TgZV33Qpo/TvSwDZM++PRfbZfxkDQpX+B2l2vAhh998ulYzS+0iDaWTXKBQWQJF8IB1Tyvh0qyHavIbsdlqy/J9NAvUzrnU6K3H/dLi1z0Fea/zMy/FpHtx4878JpCrR5J3IumX/wgT2vcq1TvvWlvOINWUuNnYC8T3dct0lxnwcjn1Qud98zTgQercvRqUUCKLYG52aAKOkpgmwQXS857RPRR4ppCu8CUmWhidMaEQnbKm4MHR/B8RN1jZQEns80HMu3+ROvM386XsrMymUH+uHsy9Q1XSzSnkuoSP0q9zBD4NSuVLUb9xB5dwhoTcRA5nalEyIFL92RVsASUtR0WmIfeHVNJHgAnwV/SBohYUlzrjF7wRntomRIw80Dqo5iDUU3ysmV8XvqqSSqyE9he95/2WHWR+4T3VGowM2+pwqVjdMMLwXqEACTH3MdE3DoILu3i+w/ltPLX2Uo2CuZwvZ+D5J0JTnnKljKEEs/wZcEItQ6asiHcDtNDO4+o9jkHtMT2qIET1vwKayq0Z/3A9IwwsHbBNWa0bJHH3DS17dPWQTzmXANT/mVS5m8r99HOvaoySRiyJhSYLXNMyNQTrQZZWQk/FWTj1KyFtB8IfjMGwPyROqVxsGLwyCHN+iduiG68Hre6e0GI+fUNuvjpnz2LjrqkQADmmcWiKge8Au+fAxZcQmvhr7byW9YMi1CdrZql2k4gtzGFU2maTXgPyzpbRBZdaYu8GZanVPUshNjNj4VEMSyzoeB0fGZMCTS4Zska8eYDulEzK2g+3evOnRJTBTW4pElWJFPnb6K7giL9yo4il8CDslRBdze4+L3P692g5yAt5jjAIAd47JAPmhn4NwkHIdaTJqTS6C0Xc6GqVD5FjbFRtBKBihe7gf8pEZZM3IiV3ZWBzlmONtI11M3xzVfY+RbypxmItmQoXPdvMFLprIIxLxbtL22brIf/oZ03900PnlTXlzP9KLB5AshJ1QEd8hxXp387raZM/Z/FfnDhjCJ2TYeD24cjesWULRQ1E=,iv:tu/VB3P13QyriUqqbv+rTky08WNQLBssukVO84JarLE=,tag:R9/ck2qlhzcLjO1vqYFjAQ==,type:str]
+nixbot-github-oauth-secret: ENC[AES256_GCM,data:GD83u7hncrWgH7INQMglEgKj8IT13XWDgKNZ58TA4tl0pJdwNm7jPw==,iv:6/W48+LWwnrsTdFSW5/P2OJ0FqnehoBHbGvok527nwE=,tag:/PIy5Znwwcx+o6CYI8Exkw==,type:str]
+nixbot-github-webhook-secret: ENC[AES256_GCM,data:FqlienTJ+zwrEqnU649FCUpWCf4fKCW3/3ni0rphTjMfhd3C8vsS/UXYSnYRgFZtfwV7mCTPyA==,iv:EtlW6cNfwMv24xHZoQFgDLnpPd4eZUbF9Fq3OJf1bmk=,tag:3NAD6+ynz1OIExfUphWTFw==,type:str]
 temp-cache-key: ENC[AES256_GCM,data:weL92egwmo4z32jXmWjgbfHo6h61+mWwHrHVAg0N8cHzBOjgsAL3NTRgpiiaePw/FcZa1rJ/ygBGyUYJbIq036fxhd1I/Vu+dPFXz7PPIphRj/q8wru21qfLXep39rk+bIqsJJB2++070SCKwgRLb4re9cM05ah3,iv:sX78dExpTL+UFkHWfQmYN8nsZcMCFhrgXwvtzvoWdJA=,tag:j3MNmXSdQEuh9oYP00yJAw==,type:str]
 sops:
     age:
-        - recipient: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFiozp1A1+SUfJQPa5DZUQcVc6CZK2ZxL6FJtNdh+2TP
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IHczV0xmQSBCZm5T
             MkVMakl4VVc0eFRjaVVsNDJTQzZqK2NneUdyYjlzaDNRMGF1UkZVCmpIS0dkVzJE
@@ -21,8 +23,8 @@ sops:
             A2TkBu4dYw0Woe4vzrJzUKgHilCRFlJNTckHzTvneTqEiI/ZI1u5U13WsgtgtNJQ
             byBjfg==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1dzvjjum2p240qtdt2qcxpm7pl2s5w36mh4fs3q9dhhq0uezvdqaq9vrgfy
-          enc: |
+          recipient: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFiozp1A1+SUfJQPa5DZUQcVc6CZK2ZxL6FJtNdh+2TP
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBME9lbHM1ZFJmc3pvRk1j
             TFByZjltQk5DYW0rWmhKMVZuMm1DYW9iR2l3CnY1V3pLMDhEZld4cklKakZOMGp0
@@ -30,8 +32,8 @@ sops:
             aUpSWkkxZ0p4Y3QwZEZFWXVxeHZuVGMKjzEv57IuFKmm0Tlxw+aYiWVJZvkyLnzL
             atqFuHTqfKpJC0IHDpr+arY4Hye/2OWeTlIyfn3l5zGAcoLAG0sKsw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1egv86plsncnz5cuaua42tzd2xqyty82n5sgnd4xkux9lz8udssds7vymye
-          enc: |
+          recipient: age1dzvjjum2p240qtdt2qcxpm7pl2s5w36mh4fs3q9dhhq0uezvdqaq9vrgfy
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVUjMrQ0NPMEM1dVRFZlJq
             UXc5aDFRRUo3RVMrTnVaNDVoR2FSaEJmUWlzClVtNWRURmQva1NzdUZYTVRxZ2Ru
@@ -39,8 +41,8 @@ sops:
             ckhuSUNyVE5LSm5ZM3dobE8xT0VVaU0KQBcg6npRtI53A6EL/qauzJS1aqZjjplt
             9gb3nERq0jQKWzKVplZzvjZHzusrIgn72MKEjUr/fjhmGn7U67+KRQ==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age17n64ahe3wesh8l8lj0zylf4nljdmqn28hvqns2g7hgm9mdkhlsvsjuvkxz
-          enc: |
+          recipient: age1egv86plsncnz5cuaua42tzd2xqyty82n5sgnd4xkux9lz8udssds7vymye
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLNUJsaTczT3VrKzhBLzJu
             OU9KOVh3alIzOFRGUy9USmFoWUsyNWxEYlZnCjJPcUVlb1JnWi85MjZ3K1NFZkhL
@@ -48,8 +50,8 @@ sops:
             RnpUeXBCK05PM0R4OWNhejNydVJrdWcKrRkcagmiXO5ue0sVxjmp+jHO8BRUqKzz
             oUbiWZ9GkcbIAoGhZe2smLu5B+u7Sz1ebuFYvOvgJtcwtF9nxqbwxw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1d87z3zqlv6ullnzyng8l722xzxwqr677csacf3zf3l28dau7avfs6pc7ay
-          enc: |
+          recipient: age17n64ahe3wesh8l8lj0zylf4nljdmqn28hvqns2g7hgm9mdkhlsvsjuvkxz
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBldmFNWnZzYnVFaHIybTVO
             TlB3UlI3QnNtY0dSSU9QOWVXTGh2MGxhaW1vCjFDcURnR1dOdXhXS3dLYTY4QnZ0
@@ -57,8 +59,8 @@ sops:
             UlFlekc3SmJiZGY4UXZhVWhUbldTdVkKw8qLM2/wcY7PMOAJWVeH6AspPy7sOShB
             yxrmffT/T0SLpuiXg9vVZjCYy4XIoWfCEYOhnpS9D+INt1YanAx6QA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h
-          enc: |
+          recipient: age1d87z3zqlv6ullnzyng8l722xzxwqr677csacf3zf3l28dau7avfs6pc7ay
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5Q1FGSlVDcWhkMGZ1VlBz
             ZlhmM2dQcEpmaEx1NHBuTEQ4aUFHaDJwSjFZCngwWkIvMmN4bzNxVzBLMjJ5T2Ry
@@ -66,8 +68,8 @@ sops:
             WHQyZ0dLbE9FYTVaUUVlNFU3NWJlNTAK1nv90wwyXY6ezEa7sohaMdXT4jTaey6Q
             NV3frXQnzePtWdzlLOrolgMnAEyICSQ6a2xhyj7DuAAw2c9LF7M++Q==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1m7xhem3qll35d539f364pm6txexvnp6k0tk34d8jxu4ry3pptv7smm0k5n
-          enc: |
+          recipient: age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFMEVjM0RIRjJIZWJDd2Ey
             K2NBbkg4VVRpYXZSV3ZVSFRVQXQrcFJ5VG1JClFBWlBZTzBldUZpdzFjUVhnMjFh
@@ -75,7 +77,8 @@ sops:
             NCtwZURNZnA2TzQwTFFqV1JQU2I1U28KqNfDY/NJbI2I0y2o+UES1qKhoMLAJJaK
             n0+Fi3VPsckNBz+H78LvwYeeiuDNkMKVFdTAf9jppbfIZ8l42RdeRg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-16T01:41:34Z"
-    mac: ENC[AES256_GCM,data:X7w24Lf6GctSD+lnemK8ScZgnXk9p62cyhEK9t4lP5GLrpn4wLSdOf6+JTF4LdC1pE7L642TQlIgrMjXw5lKNXMFu5T50in7nVuxzo22y16yWzSub/suVs1182zufpVIdiwzAtzmS57MgOgWIVEoJ6lva9AU7ek8LTvuX3utD2c=,iv:Q1i1exbl/zLnilmj4S8Mu4kJamNRd9XyRnMY7iLe1IM=,tag:DENqdPvs8mP5ScYQGayBTg==,type:str]
+          recipient: age1m7xhem3qll35d539f364pm6txexvnp6k0tk34d8jxu4ry3pptv7smm0k5n
+    lastmodified: "2026-06-11T23:54:35Z"
+    mac: ENC[AES256_GCM,data:X/rfUXGQOv5p9N8YJtpXsKA35Ee+xQ+7OrOvqqeJ66Jh87nXTbsYzBKT2bU1gBdpiP8Fqau7y+0fdyUbt21zdu3eV6Wv5Diyhi5ugwWMwraG8MwgiY2xefN4bR4G/sLqh78TRtXQFYSRRBuIKnhFxd7VAZijAcqlhB4bkF6Alsg=,iv:DF04CnzkQQEv8SvtUR/XAp5v7YBE+FMZyeyxpyIPAQM=,tag:cXCIbOMtdZu8c/GvJYKgJw==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.12.2
+    version: 3.13.1

--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -23,12 +23,9 @@ let
     "nix-community/NixNG"
     "nix-community/nixos-apple-silicon"
     "nix-community/nixos-facter"
-    "nix-community/nixos-images"
-    "nix-community/nixpkgs-update"
     "nix-community/nixpkgs-xr"
     "nix-community/nixvim"
     "nix-community/patsh"
-    "nix-community/srvos"
     "nix-community/stylix"
     # keep-sorted end
   ];

--- a/modules/nixos/monitoring/telegraf.nix
+++ b/modules/nixos/monitoring/telegraf.nix
@@ -9,6 +9,12 @@
         tags.org = "nix-community";
       }
       {
+        urls = [ "https://nixbot.nix-community.org/" ];
+        response_string_match = "Repositories";
+        tags.host = "build03.nix-community.org";
+        tags.org = "nix-community";
+      }
+      {
         urls = [ "https://hydra.nix-community.org/" ];
         response_string_match = "hosted on this server";
         tags.host = "build03.nix-community.org";

--- a/modules/nixos/nixbot.nix
+++ b/modules/nixos/nixbot.nix
@@ -1,0 +1,68 @@
+{
+  config,
+  inputs,
+  pkgs,
+  ...
+}:
+let
+  repoAllowlist = [
+    # keep-sorted start case=no
+    "nix-community/nixos-images"
+    "nix-community/nixpkgs-update"
+    "nix-community/srvos"
+    # keep-sorted end
+  ];
+
+  buildSystems = [
+    pkgs.stdenv.hostPlatform.system
+  ]
+  ++ config.nix.settings.extra-platforms
+  ++ builtins.concatLists (map (host: host.systems) config.nix.buildMachines);
+in
+{
+  imports = [
+    inputs.nixbot.nixosModules.nixbot
+  ];
+
+  services.nginx.virtualHosts."nixbot.nix-community.org" = { };
+
+  sops.secrets.nixbot-github-oauth-secret = { };
+  sops.secrets.nixbot-github-app-secret-key = { };
+  sops.secrets.nixbot-github-webhook-secret = { };
+  sops.secrets.cachix-auth-token = { };
+
+  services.nixbot = {
+    enable = true;
+    admins = [
+      "github:adisbladis"
+      "github:mdaniels5757"
+      "github:ryantm"
+      "github:zimbatm"
+      "github:zowoq"
+    ];
+    port = 8020;
+    statusContextPrefix = "buildbot";
+    inherit buildSystems;
+    domain = "nixbot.nix-community.org";
+    outputsPath = "/var/www/nixbot/nix-outputs/";
+    showTrace = true;
+    evalMaxMemorySize = 4096;
+    evalWorkerCount = 32;
+    cacheFailedBuilds = false;
+    cachix = {
+      enable = true;
+      name = "nix-community";
+      auth.authToken.file = config.sops.secrets.cachix-auth-token.path;
+    };
+    github = {
+      enable = true;
+      appId = 4016365;
+      appSecretKeyFile = config.sops.secrets.nixbot-github-app-secret-key.path;
+      webhookSecretFile = config.sops.secrets.nixbot-github-webhook-secret.path;
+      oauthSecretFile = config.sops.secrets.nixbot-github-oauth-secret.path;
+      oauthId = "Iv23li2s1vLGoe5sUdwL";
+      topic = null;
+      inherit repoAllowlist;
+    };
+  };
+}


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

I removed the nixbot renamed and removed module warnings so it can run alongside a buildbot-nix instance.

Not using this for infra repo yet, the deployment effect in this repo doesn't work and cancelling an eval seems to cache the incomplete eval with attrs missing.