### PR TITLE
modules/nixos/common/kernel: switch to dlto

### DIFF
--- a/modules/nixos/common/kernel.nix
+++ b/modules/nixos/common/kernel.nix
@@ -28,6 +28,7 @@ in
           in
           {
             LTO_CLANG_THIN = yes;
+            LTO_CLANG_THIN_DIST = yes;
             DEBUG_INFO_BTF = mkForce unset;
             NET_SCH_BPF = mkForce unset;
             SCHED_CLASS_EXT = mkForce unset;


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Should land in 7.2 kernel but we'll need to wait for it to be in a lts kernel.