### PR TITLE
modules/nixos/nixbot: add nix-darwin to pullBased

### DIFF
--- a/modules/nixos/nixbot.nix
+++ b/modules/nixos/nixbot.nix
@@ -24,6 +24,16 @@ in
     inputs.nixbot.nixosModules.nixbot
   ];
 
+  services.nixbot.pullBased = {
+    pollInterval = 3600;
+    repositories = {
+      "nix-darwin" = {
+        url = "https://github.com/nix-darwin/nix-darwin.git";
+        defaultBranch = "master";
+      };
+    };
+  };
+
   services.nginx.virtualHosts."nixbot.nix-community.org" = { };
 
   sops.secrets.nixbot-gitlab-token = { };


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

We've offered use of our CI to the nix-darwin maintainers a couple of times, previously I had created example CI runs on buildbot for them but the nix-darwin repo is low traffic so we may as well leave this enabled.