### PR TITLE
modules/nixos/nixbot: add neovim-nightly-overlay

### DIFF
--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -14,7 +14,6 @@ let
     "nix-community/home-manager"
     "nix-community/infra"
     "nix-community/lanzaboote"
-    "nix-community/neovim-nightly-overlay"
     "nix-community/nh"
     "nix-community/nix-direnv"
     "nix-community/nix-index"

--- a/modules/nixos/nixbot.nix
+++ b/modules/nixos/nixbot.nix
@@ -7,6 +7,7 @@
 let
   repoAllowlist = [
     # keep-sorted start case=no
+    "nix-community/neovim-nightly-overlay"
     "nix-community/nixos-images"
     "nix-community/nixpkgs-update"
     "nix-community/srvos"


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

@GaetanLepage I'd like to move `neovim-nightly-overlay` to https://nixbot.nix-community.org, it is able to replace buildbot-nix and hercules CI. Example nixbot effect flake update: https://github.com/nix-community/srvos/pull/845.