### PR TITLE
modules/nixos/buildbot: remove nixvim

### DIFF
--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -22,7 +22,6 @@ let
     "nix-community/nixos-apple-silicon"
     "nix-community/nixos-facter"
     "nix-community/nixpkgs-xr"
-    "nix-community/nixvim"
     "nix-community/patsh"
     "nix-community/stylix"
     "NixOS/home-manager"


### PR DESCRIPTION
moved to nixbot in 9205dc2a148bd287def7e3bf94fb6c9e4afcf599

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->