### PR TITLE
docs/continuous-integration: add nixbot, remove buildbot, remove hercules

### DIFF
--- a/devdoc/onboarding.md
+++ b/devdoc/onboarding.md
@@ -10,7 +10,7 @@
 
   - [Terraform Cloud](https://app.terraform.io)
 
-- Add their user to the list of `admins` in [modules/nixos/buildbot.nix](../modules/nixos/buildbot.nix).
+- Add their user to the list of `admins` in [modules/nixos/nixbot.nix](../modules/nixos/nixbot.nix).
 
 - Add their user to the list of `hydra-github-users` in [modules/nixos/hydra.nix](../modules/nixos/hydra.nix).
 

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -10,13 +10,13 @@ We only have limited build capacity for `aarch64-darwin` so please don't use it 
 
 See [here](infrastructure.md#continuous-integration) for details about the hardware.
 
-#### Buildbot
+#### Nixbot
 
-[https://buildbot.nix-community.org](https://buildbot.nix-community.org)
+[https://nixbot.nix-community.org](https://nixbot.nix-community.org)
 
-_Buildbot is the only CI system that supports pull requests from forked repositories._
+_Nixbot is the only CI system that supports pull requests from forked repositories._
 
-To enable buildbot add the repository to the `repoAllowlist` in this [file](https://github.com/nix-community/infra/blob/master/modules/nixos/buildbot.nix).
+To enable nixbot add the repository to the `repoAllowlist` in this [file](https://github.com/nix-community/infra/blob/master/modules/nixos/nixbot.nix).
 
 #### Hercules
 

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -18,12 +18,6 @@ _Nixbot is the only CI system that supports pull requests from forked repositori
 
 To enable nixbot add the repository to the `repoAllowlist` in this [file](https://github.com/nix-community/infra/blob/master/modules/nixos/nixbot.nix).
 
-#### Hercules
-
-[https://hercules-ci.com/github/nix-community](https://hercules-ci.com/github/nix-community)
-
-To enable hercules go to `https://hercules-ci.com/github/nix-community/$REPO` and click "Build this repository".
-
 #### Hydra
 
 [https://hydra.nix-community.org](https://hydra.nix-community.org)


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

Dropping buildbot and hercules from the docs as new projects that want to use our CI should use nixbot.