### PR TITLE
modules/nixos/nixbot: add home-manager

### DIFF
--- a/modules/nixos/nixbot.nix
+++ b/modules/nixos/nixbot.nix
@@ -7,12 +7,14 @@
 let
   repoAllowlist = [
     # keep-sorted start case=no
+    "nix-community/home-manager"
     "nix-community/infra"
     "nix-community/neovim-nightly-overlay"
     "nix-community/nixos-images"
     "nix-community/nixpkgs-update"
     "nix-community/nixvim"
     "nix-community/srvos"
+    "NixOS/home-manager"
     # keep-sorted end
   ];
 


### PR DESCRIPTION
<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->

@khaneliman Would you be okay with enabling nixbot alongside buildbot for `home-manager` the same as was done with `nixvim`? Might be easier if we can make sure the repo is running fine on nixbot and moved off buildbot before the repo is moved to the nixos org?