### PR TITLE
modules/nixos/nixbot: remove port

### DIFF
--- a/modules/nixos/nixbot.nix
+++ b/modules/nixos/nixbot.nix
@@ -57,7 +57,6 @@ in
       "github:zimbatm"
       "github:zowoq"
     ];
-    port = 8020;
     inherit buildSystems;
     domain = "nixbot.nix-community.org";
     outputsPath = "/var/www/nixbot/nix-outputs/";


### PR DESCRIPTION
don't need to set this, unix socket is the default

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
