### PR TITLE
darwin/community-builder: add hythera

### DIFF
--- a/modules/darwin/community-builder/keys/hythera
+++ b/modules/darwin/community-builder/keys/hythera
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICG+RRAvYBqxzM80DkGvC3bnnZ7wrXRMUsAYhRBpw3gn hythera@hytheron

--- a/modules/darwin/community-builder/users.nix
+++ b/modules/darwin/community-builder/users.nix
@@ -573,6 +573,13 @@ let
       uid = 586;
       keys = ./keys/gepbird;
     }
+    {
+      # lib.maintainers.hythera, https://github.com/Hythera
+      name = "hythera";
+      trusted = true;
+      uid = 587;
+      keys = ./keys/hythera;
+    }
   ];
 in
 {


### PR DESCRIPTION
With `x86_64-darwin` going out of support now I don't have a reliable way to test and debug package updates / fixes on `darwin` anymore. It has mostly come very much in handy when doing packgage updates that cause mass-rebuilds.
Access to the darwin community builder would allow me to build, test, debug package updates of PRs I review / my own ones again.
