### PR TITLE
Revert "modules/nixos/disko-zfs-systemd-boot: enable bootCounting"

### DIFF
--- a/modules/nixos/disko-zfs-systemd-boot.nix
+++ b/modules/nixos/disko-zfs-systemd-boot.nix
@@ -31,7 +31,6 @@ in
   imports = [ inputs.disko.nixosModules.disko ];
 
   boot.loader.systemd-boot.enable = true;
-  boot.loader.systemd-boot.bootCounting.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
   # suppress warning, https://github.com/NixOS/nixpkgs/commit/dfd0f18d9df417bb185d95ac806c220049fbfca1


### PR DESCRIPTION
systemd-bless-boot seems to fail consistently on build02, disabling it on all hosts for now

This reverts commit e35339d369134f6788c7717b4450ce0da7529f96.

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
