### PR TITLE
docs: remove links to deleted repo

### DIFF
--- a/docs/community-builders.md
+++ b/docs/community-builders.md
@@ -70,5 +70,3 @@ $ ssh build-box.nix-community.org
 $ nix-store -r $path
 $ $path
 ```
-
-_(My [implementation](https://github.com/ckiee/nixfiles/blob/aac57f56e417e31f00fd495d8a30fb399ecbc19b/deploy/hm-only.nix#L10) of [this](https://github.com/ckiee/nixfiles/blob/aac57f56e417e31f00fd495d8a30fb399ecbc19b/bin/c#L92-L95) ~ckie)_


### PR DESCRIPTION
@ckiee if your repo is still public somewhere or you could make these resources available via a public or secret gist, please open a PR with the correct resources.