### PR TITLE
docs: add example home-manager url

### DIFF
--- a/docs/community-builders.md
+++ b/docs/community-builders.md
@@ -70,3 +70,5 @@ $ ssh build-box.nix-community.org
 $ nix-store -r $path
 $ $path
 ```
+
+_(My implementation of [this](https://gist.github.com/ckiee/f7768f55a938aa7c985406f209a6f114) ~ckie)_


### PR DESCRIPTION
recently removed in #2335

Link is from the comment https://github.com/nix-community/infra/pull/2335#issuecomment-4944205729