### PR TITLE
modules/shared/nix-daemon: disable temp-cache on build03

### DIFF
--- a/modules/shared/nix-daemon.nix
+++ b/modules/shared/nix-daemon.nix
@@ -1,6 +1,7 @@
 {
   config,
   inputs,
+  lib,
   pkgs,
   ...
 }:
@@ -12,11 +13,15 @@ in
   nix = {
     settings.trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ]
+    ++ lib.optionals (config.networking.hostName != "build03") [
       "temp-cache.nix-community.org-1:RSXIfGjilfBsilDvj03/VnL/9qAxacBnb1YQvSdCoDc="
     ];
 
     settings.substituters = [
       "https://nix-community.cachix.org"
+    ]
+    ++ lib.optionals (config.networking.hostName != "build03") [
       "https://temp-cache.nix-community.org"
     ];
 


### PR DESCRIPTION
this cache is hosted on build03

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
