### PR TITLE
Move `bun2nix` from `buildbot` to `nixbot`

### DIFF
--- a/modules/nixos/buildbot.nix
+++ b/modules/nixos/buildbot.nix
@@ -8,7 +8,6 @@ let
   repoAllowlist = [
     # keep-sorted start case=no
     "nix-community/authentik-nix"
-    "nix-community/bun2nix"
     "nix-community/dream2nix"
     "nix-community/ethereum.nix"
     "nix-community/lanzaboote"

--- a/modules/nixos/nixbot.nix
+++ b/modules/nixos/nixbot.nix
@@ -7,6 +7,7 @@
 let
   repoAllowlist = [
     # keep-sorted start case=no
+    "nix-community/bun2nix"
     "nix-community/home-manager"
     "nix-community/infra"
     "nix-community/neovim-nightly-overlay"


### PR DESCRIPTION
Moves `bun2nix` from the `buildbot` allow list to the `nixbot` one, as [requested here](https://github.com/orgs/nix-community/discussions/2331).
