### PR TITLE
darwin/community-builder: add whispers

### DIFF
--- a/modules/darwin/community-builder/keys/whispers
+++ b/modules/darwin/community-builder/keys/whispers
@@ -1,0 +1,2 @@
+no-touch-required sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIEHn+mgQW4uhrI0VDee9zSF9UTgnUnTpo+Zzz4QuTHU6AAAABHNzaDo= whispers@nyx
+no-touch-required sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIMVn/dx7qMzKPyDfRQa0uOozopizPiCi8sikK1XpvxpAAAAABHNzaDo= whispers@hemera

--- a/modules/darwin/community-builder/users.nix
+++ b/modules/darwin/community-builder/users.nix
@@ -592,6 +592,13 @@ let
       uid = 589;
       keys = ./keys/thunze;
     }
+    {
+      # lib.maintainers.whispersofthedawn, https://github.com/whispersofthedawn
+      name = "whispers";
+      trusted = true;
+      uid = 590;
+      keys = ./keys/whispers;
+    }
   ];
 in
 {


### PR DESCRIPTION
I'd like to request access to the Darwin community builder in order to better contribute to Nixpkgs. I contribute a decent bit ([my prs](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+author%3Awhispersofthedawn)), including quite a few changes that touch many packages ([my `staging` prs](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+author%3Awhispersofthedawn+base%3Astaging)). Generally, other than routine package bumps, I tend to contribute to various cleanups and build fixes on staging-next, as well as working on specific efforts like [gcc 16](http://redirect.github.com/nixos/nixpkgs/pull/537781). Given that a lot of these changes touch many packages and are often high impact and can cause problems (e.g. I'm told that the latest Rust bump is currently causing issues for Darwin on staging), it would be very beneficial to be able to test them in some capacity on aarch64-darwin since I have access to {x86_64,aarch64}-linux hardware, but no darwin as it is. I am aware that this machine is somewhat overcommitted and would be careful with usage if I got access. Thanks for the consideration!