### PR TITLE
{darwin,nixos}/community-builder: add user tyceherrman

### DIFF
--- a/modules/darwin/community-builder/keys/tyceherrman
+++ b/modules/darwin/community-builder/keys/tyceherrman
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMxnQhAj5tJBoRWG6GJNB7Kj833y9PLmk4cHWsfciKp4 nixpkgs-review-gha

--- a/modules/darwin/community-builder/users.nix
+++ b/modules/darwin/community-builder/users.nix
@@ -599,6 +599,13 @@ let
       uid = 590;
       keys = ./keys/whispers;
     }
+    {
+      # lib.maintainers.tyceherrman, https://github.com/TyceHerrman
+      name = "tyceherrman";
+      trusted = true;
+      uid = 591;
+      keys = ./keys/tyceherrman;
+    }
   ];
 in
 {

--- a/modules/nixos/community-builder/keys/tyceherrman
+++ b/modules/nixos/community-builder/keys/tyceherrman
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMxnQhAj5tJBoRWG6GJNB7Kj833y9PLmk4cHWsfciKp4 nixpkgs-review-gha

--- a/modules/nixos/community-builder/users.nix
+++ b/modules/nixos/community-builder/users.nix
@@ -567,6 +567,12 @@ let
       trusted = true;
       keys = ./keys/thunze;
     }
+    {
+      # lib.maintainers.tyceherrman, https://github.com/TyceHerrman
+      name = "tyceherrman";
+      trusted = true;
+      keys = ./keys/tyceherrman;
+    }
   ];
 in
 {


### PR DESCRIPTION
Requesting trusted access to the Linux and Darwin community builders for my [`nixpkgs-review-gha` fork](https://github.com/TyceHerrman/nixpkgs-review-gha).

- Nixpkgs maintainer: `lib.maintainers.tyceherrman`
- Key scope: limited to `nixpkgs-review-gha`

<!--

If you are requesting access to the community builders please also join our matrix room:

https://matrix.to/#/#nix-community:nixos.org

-->
