### PR TITLE
nixpkgs-update: exclude Lix/Nix overrides before deduplication

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,7 @@
             ];
           };
 
-          hostModuleDir = ./hosts;
+          hostModuleDir = "${self}/hosts";
 
           hosts = {
             build01.system = "x86_64-linux";

--- a/hosts/build02/packages-with-update-script.nix
+++ b/hosts/build02/packages-with-update-script.nix
@@ -93,9 +93,13 @@ in
 
 let
 
-  allPackagesWithUpdateScript = packagesWithUpdateScriptMatchingPredicate (
-    _path: _package: true
-  ) pkgs;
+  allPackagesWithUpdateScript = packagesWithUpdateScriptMatchingPredicate (_path: _package: true) (
+    # exclude lix/nix overrides before deduplication
+    builtins.removeAttrs pkgs [
+      "lixPackageSets"
+      "nixDependencies"
+    ]
+  );
 
 in
 


### PR DESCRIPTION
The updateScript collector deduplicates packages by `updateScript` and `meta.position` before passing its output through `filter.sed`. An excluded override can displace its canonical package. `lixPackageSets.git.nix-init` wins deduplication and then the filter removes it, leaving no `nix-init` candidate from updateScript discovery.

PR removes `lixPackageSets` and `nixDependencies` from the initial package set before recursive discovery. These scopes are already excluded by the downstream filter, which remains in place for the other update sources.

PR also adds a focused Linux flake check that runs the actual collector with a small package fixture and applies the GNU sed filter. Exact raw and filtered output comparisons cover both excluded scopes, canonical candidates, ordinary alias deduplication, shared updaters with distinct positions, and packages without an updater. The fetcher's command interface is unchanged.

A separate commit changes `hostModuleDir` to `"${self}/hosts"`, keeping host imports within the flake source. This avoids creating a separate `*-hosts` store path during read-only evaluation.

Validation:

- Infra's full repository formatter check passed: 365 processed files, zero changes.
- The packaged regression passed in OrbStack for `aarch64-linux` and `x86_64-linux` using infra's locked Nixpkgs input. The test is registered in the repository's `x86_64-linux` checks.
- The focused regression fails with the original collector and when either exclusion is independently removed.
- With the unchanged GNU sed filter there were 19,400 rows before and 19,406 after with no removed rows, including duplicate counts. The only additions are `nil`, `nix-fast-build`, `nix-init`, `nix-update`, `nixos-rebuild-ng`, and `nixpkgs-review`.
- The host-path change passes a cold-store reproducer under Lix 2.95.2 and Nix 2.34.8; the original path-valued version fails under both.
- `git diff --check` passed.
- `nix flake check --no-build --no-write-lock-file` passed on `aarch64-darwin`, including both Darwin hosts and all six NixOS configurations. The default command omitted Linux-specific flake checks. Copies required by the locked `flake-compat`, `flake-parts`, and `buildbot-nix` inputs were materialized locally first; this does not establish a passing cold-store check.

The exclusions were introduced in [#2005](https://github.com/nix-community/infra/pull/2005).
